### PR TITLE
ROOT fix, https behind reverse proxy, debug error fix

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -10,7 +10,7 @@
 // initialize session
 wdf_session_start();
 // check debug from session
-if($_SESSION['wikidocs']['debug']){$debug=true;}
+if(isset($_SESSION['wikidocs']['debug']) && ($_SESSION['wikidocs']['debug'] == 1)){$debug=true;}
 // check debug from requests
 if(isset($_GET['debug'])){
  if($_GET['debug']==1){$debug=true;$_SESSION['wikidocs']['debug']=true;}

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -36,7 +36,7 @@ if(!strlen($g_doc)){$g_doc="homepage";}
 define("DEBUG",$debug);
 define("VERSION",file_get_contents("VERSION.txt"));
 define("HOST",(isset($_SERVER['HTTPS'])?"https":"http")."://".$_SERVER['HTTP_HOST']);
-define("ROOT",rtrim(str_replace("\\","/",realpath(dirname(__FILE__))."/"),PATH));
+define("ROOT",str_replace(PATH, "", str_replace("\\","/",realpath(dirname(__FILE__))."/")));
 define("URL",HOST.PATH);
 define("DIR",ROOT.PATH);
 define("DOC",$g_doc);

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -16,6 +16,8 @@ if(isset($_GET['debug'])){
  if($_GET['debug']==1){$debug=true;$_SESSION['wikidocs']['debug']=true;}
  else{$debug=false;$_SESSION['wikidocs']['debug']=false;}
 }
+// if behind https reverse proxy, set HTTPS property correctly
+if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') $_SERVER['HTTPS']='on';
 // errors settings
 error_reporting(E_ALL & ~E_NOTICE);
 ini_set("display_errors",$debug);

--- a/setup.php
+++ b/setup.php
@@ -29,7 +29,7 @@
   // reset session setup
   $_SESSION['wikidocs']['setup']=null;
   // build dir from given path
-  $dir=rtrim(str_replace("\\","/",realpath(dirname(__FILE__))."/"),$_POST['path']).$_POST['path'];
+  $dir=str_replace($_POST['path'], "", str_replace("\\","/",realpath(dirname(__FILE__))."/")).$_POST['path'];
   // check setup
   if(file_exists($dir."setup.php")){$checks_array['path']=true;}else{$checks_array['path']=false;$errors=true;}
   if(strlen($_POST['title'])){$checks_array['title']=true;}else{$checks_array['title']=false;$errors=true;}


### PR DESCRIPTION
Hopefully an all-in-one PR is ok.

- I installed WikiDocs on alpine linux, and the default apache path on alpine is `/var/www/localhost/htdocs/`. WikiDocs was under that directory as `/wikidocs/`,
With the `rtrim()` method when setting ROOT, it actually trimmed out the "docs" part of "htdocs" in the path, which caused all sorts of issues.
Replacing `rtrim()` with `str_replace()` seems to work perfectly.

- The check for `$_SERVER['HTTPS']` isn't aware of HTTPS reverse proxies in front of WikiDocs, so adding a check for `HTTP_X_FORWARDED_PROTO` fixes errors I was getting from `editor.js` requesting http...submit.php instead of https.

- Lastly, my apache error log was filled with `Undefined variable: debug` errors if debug wasn't set, which by default, it isn't.
Adding an `isset()` check fixed that issue.