### PR TITLE
use substr and strrpos to fix the ROOT issues

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -38,8 +38,9 @@ if(!strlen($g_doc)){$g_doc="homepage";}
 define("DEBUG",$debug);
 define("VERSION",file_get_contents("VERSION.txt"));
 define("HOST",(isset($_SERVER['HTTPS'])?"https":"http")."://".$_SERVER['HTTP_HOST']);
-//define("ROOT",str_replace(PATH, "", str_replace("\\","/",realpath(dirname(__FILE__))."/"))); /* @todo check with reyemxela */
-define("ROOT",rtrim(str_replace("\\","/",realpath(dirname(__FILE__))."/"),PATH));
+$orig_dir=str_replace("\\","/",realpath(dirname(__FILE__))."/");
+define("ROOT",substr($orig_dir, 0, strrpos($orig_dir, PATH)));
+//define("ROOT",rtrim(str_replace("\\","/",realpath(dirname(__FILE__))."/"),PATH));
 define("URL",HOST.PATH);
 define("DIR",ROOT.PATH);
 define("DOC",$g_doc);

--- a/setup.php
+++ b/setup.php
@@ -29,7 +29,9 @@
   // reset session setup
   $_SESSION['wikidocs']['setup']=null;
   // build dir from given path
-  $dir=str_replace($_POST['path'], "", str_replace("\\","/",realpath(dirname(__FILE__))."/")).$_POST['path'];
+  $orig_dir=str_replace("\\","/",realpath(dirname(__FILE__))."/");
+  $dir=substr($orig_dir, 0, strrpos($orig_dir, (string)$_POST['path'])).$_POST['path'];
+  //$dir=str_replace($_POST['path'], "", str_replace("\\","/",realpath(dirname(__FILE__))."/")).$_POST['path'];
   // check setup
   if(file_exists($dir."setup.php")){$checks_array['path']=true;}else{$checks_array['path']=false;$errors=true;}
   if(strlen($_POST['title'])){$checks_array['title']=true;}else{$checks_array['title']=false;$errors=true;}
@@ -44,7 +46,9 @@
  // conclude action
  if($g_act=="conclude"){
   // build dir from given path
-  $dir=rtrim(str_replace("\\","/",realpath(dirname(__FILE__))."/"),$_POST['path']).$_POST['path'];
+  $orig_dir=str_replace("\\","/",realpath(dirname(__FILE__))."/");
+  $dir=substr($orig_dir, 0, strrpos($orig_dir, (string)$_POST['path'])).$_POST['path'];
+  //$dir=rtrim(str_replace("\\","/",realpath(dirname(__FILE__))."/"),$_POST['path']).$_POST['path'];
   // build configuration file
   $config="<?php\n";
   $config.="define(\"PATH\",\"".$_SESSION['wikidocs']['setup']['path']."\");\n";


### PR DESCRIPTION
This should fix my issues with `rtrim`, and also the removing-slashes issue with `str_replace` when PATH is just /. I tested both configurations on my end to make sure this did actually work for both use-cases.

I also realized `setup.php` was kinda using both old methods (my bad), so I fixed that up to use this new method correctly.