### PR TITLE
remove extra PATH from $root_dir

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -33,7 +33,7 @@ if(substr($g_doc,-1)=="/"){$g_doc=substr($g_doc,0,-1);}
 if(!strlen($g_doc)){$g_doc="homepage";}
 // make root dir from given path
 $original_dir=str_replace("\\","/",realpath(dirname(__FILE__))."/");
-$root_dir=substr($original_dir,0,strrpos($original_dir,(string)PATH)).PATH;
+$root_dir=substr($original_dir,0,strrpos($original_dir,(string)PATH));
 
 /**
  * Definitions

--- a/setup.php
+++ b/setup.php
@@ -26,7 +26,7 @@
  if(file_exists("config.inc.php")){die("Wiki|Docs is already configured..");}
  // make root dir from given path
  $original_dir=str_replace("\\","/",realpath(dirname(__FILE__))."/");
- $root_dir=substr($original_dir,0,strrpos($original_dir,(string)$_POST['path'])).$_POST['path'];
+ $root_dir=substr($original_dir,0,strrpos($original_dir,(string)$_POST['path']));
  // check action
  if($g_act=="check"){
   // reset session setup


### PR DESCRIPTION
I think in the re-shuffling of things, this extra PATH got appended to `$root_dir`.
It's working on the [main site](https://www.wikidocs.it) because the PATH there is just "/", and the double-PATH isn't easily noticed.

Would probably fix #14 too, as that's what my install started doing after this.