### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM alpine:3
+
+RUN apk add --no-cache \
+    apache2 \
+    php7 \
+    php7-apache2 \
+    php7-session \
+    php7-mbstring \
+    php7-json \
+    shadow \
+    curl
+
+# enable rewrite module and allow .htaccess overrides
+RUN sed -i "s/#LoadModule\ rewrite_module/LoadModule\ rewrite_module/" /etc/apache2/httpd.conf && \
+    printf "\n<Directory \"/var/www/localhost/htdocs\">\n\tAllowOverride All\n</Directory>\n" >> /etc/apache2/httpd.conf && \
+    rm -f /var/www/localhost/htdocs/index.html
+
+# download and extract wikidocs archive
+RUN curl -Lso wikidocs.tar.gz https://github.com/Zavy86/WikiDocs/archive/master.tar.gz && \
+    tar --strip-components=1 -xf wikidocs.tar.gz -C /var/www/localhost/htdocs/ && \
+    rm wikidocs.tar.gz && \
+    cd /var/www/localhost/htdocs && \
+    sed -i "s/config\.inc\.php/config\/config.inc.php/" setup.php update.php functions.inc.php && \
+    mkdir config && \
+    ln -s /var/www/localhost/htdocs/config / && \
+    ln -s /var/www/localhost/htdocs/documents /
+
+# pre-populate the .htaccess file so if we supply a config.inc.php, everything still works
+RUN echo -e \
+'<IfModule mod_rewrite.c>\n'\
+'RewriteEngine On\n'\
+'RewriteBase /\n'\
+'RewriteCond %{REQUEST_FILENAME} !-f\n'\
+'RewriteRule ^(.*)$ index.php?doc=$1 [NC,L,QSA]\n'\
+'</IfModule>' >/var/www/localhost/htdocs/.htaccess
+
+# start script to override apache user's uid/gid
+RUN echo -e \
+'#!/bin/sh\n'\
+'groupmod -o -g ${PGID:-1000} apache\n'\
+'usermod -o -u ${PUID:-1000} apache\n'\
+'chown -R apache:apache /var/www/localhost/htdocs\n'\
+'exec httpd -D FOREGROUND' > /start.sh
+RUN chmod +x /start.sh
+
+WORKDIR /var/www/localhost/htdocs
+EXPOSE 80
+VOLUME /documents
+VOLUME /config
+
+ENTRYPOINT ["/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3
+FROM alpine:3.15
 
-RUN apk add --no-cache \
+RUN apk update && apk upgrade && apk add --no-cache \
     apache2 \
     php7 \
     php7-apache2 \


### PR DESCRIPTION
This PR is to request that we keep a maintained Dockerfile as part of the repo.

The Dockerfile was lifted from [reyemxela](https://hub.docker.com/r/reyemxela/wikidocs/Dockerfile).

It was slightly modified by pinning `alpine:3.15` because this Dockerfile relies on `php7`, but `alpine:3.16` uses `php8` [[source](https://pkgs.alpinelinux.org/packages?name=php*&branch=v3.15)].  It may be possible to upgrade to `php8`, but I didn't look closely.

All of this was motivated by a desire to have a docker image that supports multiple architectures.

I built [sam6174/wikidocs](https://hub.docker.com/r/sam6174/wikidocs) via:

```shell
docker buildx build \
  --push \
  --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 \
  --tag sam6174/wikidocs:latest \
  .
```

@reyemxela What do you think about updating your image to support multiple architectures?