### PR TITLE
Stylesheet improvements

### DIFF
--- a/styles/styles-dark.css
+++ b/styles/styles-dark.css
@@ -43,10 +43,15 @@ ul.sidenav.sidenav-fixed li.subsub_index.active{background-color:#555 !important
 .sidebar-footer .default-title:before{color:#ffffff;}
 
 /* simplemde */
-.editor-toolbar .easymde-dropdown,.editor-toolbar button{color:#ccc;}
+.EasyMDEContainer .CodeMirror {color:#ccc;border-color:#ccc;background-color:#444;}
+.EasyMDEContainer .editor-toolbar > * {color:#ccc;}
+.EasyMDEContainer .editor-toolbar > .active, .editor-toolbar > button:hover, .editor-preview pre, .cm-s-easymde .cm-comment{color:#ccc;background-color:#23241F;}
 .editor-toolbar.fullscreen{background:#333;}
-.EasyMDEContainer .CodeMirror-fullscreen{background: #e7e7e7;}
-.editor-preview{background:#333;}
+.EasyMDEContainer .CodeMirror-fullscreen{background:#444;color:#ccc;}
+.editor-preview{background:#333;color:#ccc;}
+.CodeMirror-selectedtext{background-color: #d9d9d9 !important;color: #444 !important;}
+::selection{background-color: #d9d9d9 !important;color: #444 !important;}
+::-moz-selection{background-color: #d9d9d9 !important;color: #444 !important;}
 
 /* inputs */
 label{color:#ccc;}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -24,6 +24,11 @@ h4{font-size:2.0rem;margin:1.0rem 0 1.0rem 0;}
 h5{font-size:1.5rem;margin:0.75rem 0 1.0rem 0;}
 h6{font-size:1.0rem;margin:0.5rem 0 1.0rem 0;}
 
+/* reset editor-preview ul */
+.editor-preview ul,.editor-preview ol{padding-left:20px !important;margin-top:10px !important;margin-bottom:15px !important;}
+.editor-preview ul li,.editor-preview ul li{list-style-type: initial !important;}
+.editor-preview ul ul,.editor-preview ul ul{padding-left:20px !important;margin-top:0 !important;margin-bottom:0 !important;}
+
 /* reset article ul */
 article ul,article ol{padding-left:30px !important;margin-top:10px !important;margin-bottom:15px !important;}
 article ul li,article ul li{list-style-type: initial !important;}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -25,6 +25,7 @@ h5{font-size:1.5rem;margin:0.75rem 0 1.0rem 0;}
 h6{font-size:1.0rem;margin:0.5rem 0 1.0rem 0;}
 
 /* reset editor-preview ul */
+.editor-preview pre {padding: 1em;white-space: pre-wrap;}
 .editor-preview ul,.editor-preview ol{padding-left:20px !important;margin-top:10px !important;margin-bottom:15px !important;}
 .editor-preview ul li,.editor-preview ul li{list-style-type: initial !important;}
 .editor-preview ul ul,.editor-preview ul ul{padding-left:20px !important;margin-top:0 !important;margin-bottom:0 !important;}


### PR DESCRIPTION
This fixes:
- OL and UL not displaying correctly while in edit mode
- Adds text wrapping while editing so user doesn't need to scroll horizontally all the time
- Improves simplemde stylesheet for dark theme

Light theme editor:
![light](https://github.com/Zavy86/WikiDocs/assets/3268946/c7e341ce-736b-45ac-ad47-30e8a1ee5feb)

Dark theme editor:
![dark](https://github.com/Zavy86/WikiDocs/assets/3268946/5b46c8b0-9749-4a5a-a362-a9a091bb2e4e)
