### PR TITLE
multi level ol/ul stylesheet fixes

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -26,14 +26,19 @@ h6{font-size:1.0rem;margin:0.5rem 0 1.0rem 0;}
 
 /* reset editor-preview ul */
 .editor-preview pre {padding: 1em;white-space: pre-wrap;}
-.editor-preview ul,.editor-preview ol{padding-left:20px !important;margin-top:10px !important;margin-bottom:15px !important;}
-.editor-preview ul li,.editor-preview ul li{list-style-type: initial !important;}
-.editor-preview ul ul,.editor-preview ul ul{padding-left:20px !important;margin-top:0 !important;margin-bottom:0 !important;}
+.editor-preview ul,.editor-preview ol{padding-left:20px !important;}
+.editor-preview ul ul, .editor-preview ol ul{margin:0px !important;}
+.editor-preview ul li{list-style-type: initial !important;}
+.editor-preview ul ul{padding-left:20px !important;margin-top:0 !important;margin-bottom:0 !important;}
 
 /* reset article ul */
 article ul,article ol{padding-left:30px !important;margin-top:10px !important;margin-bottom:15px !important;}
-article ul li,article ul li{list-style-type: initial !important;}
-article ul ul,article ul ul{padding-left:30px !important;margin-top:0 !important;margin-bottom:0 !important;}
+article ul p, article ol p{margin:0px !important;}
+article ul li{list-style-type: initial !important;}
+article ul ol{margin-top:0 !important;margin-bottom:0 !important;}
+article ul ol li{display: list-item !important;list-style-type:decimal !important;}
+article ol ul,article ol ol{margin-top:0 !important;margin-bottom:0 !important;}
+article ul ul{padding-left:30px !important;margin-top:0 !important;margin-bottom:0 !important;}
 
 /* justify article p */
 /*article p{text-align:justify;}*/


### PR DESCRIPTION
This fixes inconsistencies and spacing in multi level ol/ul. Also UL > OL was showing bullets instead of numbers...

Sorry for multiple MRs. My OCD wasn't letting go. But it is all good now.

Before:
![before](https://github.com/Zavy86/WikiDocs/assets/3268946/12325d17-b6f4-4810-a5d6-6f021e81cf50)

After:
![after](https://github.com/Zavy86/WikiDocs/assets/3268946/6a23ec48-d680-4288-9701-e121c4564a1a)
