### PR TITLE
translation update and search result improvement

### DIFF
--- a/localizations/fa.json
+++ b/localizations/fa.json
@@ -63,6 +63,7 @@
 	"SettingsGtag": "Google Analytics tag",
 	"SettingsGtagPlaceholder": "Insert G-TAG",
 	"SettingsLanguage": "زبان",
+	"SettingsTimezone": "منطقه زمانی",
 	"SettingsCancel": "لغو",
 	"SettingsSubmit": "ذخیره",
 	"SubmitAuthSuccess": "باموفقیت وارد سیستم شدید.",

--- a/localizations/zh-hans.json
+++ b/localizations/zh-hans.json
@@ -63,6 +63,7 @@
     "SettingsGtag": "Google Analytics标签",
     "SettingsGtagPlaceholder": "插入G-TAG",
     "SettingsLanguage": "语言",
+    "SettingsTimezone": "时区",
     "SettingsCancel": "取消",
     "SettingsSubmit": "保存",
     "SubmitAuthSuccess": "验证成功!",

--- a/localizations/zh-hant.json
+++ b/localizations/zh-hant.json
@@ -63,6 +63,7 @@
     "SettingsGtag": "Google Analytics標籤",
     "SettingsGtagPlaceholder": "插入G-TAG",
     "SettingsLanguage": "語言",
+    "SettingsTimezone": "時區",
     "SettingsCancel": "取消",
     "SettingsSubmit": "保存",
     "SubmitAuthSuccess": "驗證成功!",

--- a/template.inc.php
+++ b/template.inc.php
@@ -280,7 +280,7 @@
 					<article>
 						<h1><?= $TXT->SearchResults ?></h1>
 						<?php foreach($matches_array=Document::search(SEARCH) as $document_fe=>$matches_fe): ?>
-							<hr><h5><a href="<?= URL.$document_fe ?>" target="_blank"><b><?= $document_fe ?></b></a></h5>
+							<hr><h5><a href="<?= URL.$document_fe ?>"><b><?= $document_fe ?></b></a></h5>
 							<?php foreach($matches_fe as $match_fe): ?>
 								<p><?= $match_fe ?></p>
 							<?php endforeach; ?>


### PR DESCRIPTION
- adds translation for timezone
- removes `target=_blank` from search result

Second change is up for discussion but I think if anybody want to open a search result in a new tab, they can do it
with the middle mouse button or with ctrl+click. But if by default it opens in a new tab, the there's no way not to open it in the same tab...

@Zavy86 what do you think about not opening search results in a new tab?