### PR TITLE
Update PHP and Alpine, fixes 78

### DIFF
--- a/docker/production.dockerfile
+++ b/docker/production.dockerfile
@@ -13,15 +13,15 @@
 # docker buildx build -f docker/production.dockerfile --platform linux/amd64,linux/arm64 --no-cache --push -t zavy86/wikidocs .
 #
 
-FROM alpine:3.15
+FROM alpine
 
 ARG DEPENDENCIES="\
 apache2 \
-php7 \
-php7-apache2 \
-php7-json \
-php7-mbstring \
-php7-session \
+php82 \
+php82-apache2 \
+php82-json \
+php82-mbstring \
+php82-session \
 shadow \
 "
 


### PR DESCRIPTION
Use latest Alpine
Use php82 packages, seems to work fine.

This requires a manual bump of PHP, whenever the next version is out, and no issues were recognized in the dev container.
This will also break when ever the php82 package in Alpine becomes unavailable.

An alternative would be to just use latest PHP, but then things might suddenly break in case of WikiDocs being incompatible with some future PHP version.
