### PR TITLE
Fix search error 500 when:

### DIFF
--- a/classes/Document.class.php
+++ b/classes/Document.class.php
@@ -413,6 +413,12 @@ final class Document{
 	 * @return array of results
 	 */
 	static function search(string $query,?string $parent=null):array{
+		// trim the query to remove leading and trailing spaces
+		$query = trim($query);
+		// return an empty array if the query is empty after trimming
+		if (empty($query)) {
+			return array();
+		}
 		// tree to array
 		function tree_to_array(&$array,$parent=null){
 			foreach(Document::list($parent) as $dir_fe){


### PR DESCRIPTION
- search is empty
- search contains leading and/or trailing spaces

Tried to add literral search with double qotes like searching `"extact text"` but couldn't make it work. I will try again later.