### PR TITLE
Use password_hash instead of md5 (backward compatible)

### DIFF
--- a/datasets/sample.config.inc.php
+++ b/datasets/sample.config.inc.php
@@ -22,9 +22,9 @@ define('OWNER',"Owner");
 define('NOTICE',"Credits");
 // Privacy banner for GDPR-compliant
 define('PRIVACY',null);
-// MD5 encoded password for editing (default',password)
-define('EDITCODE',"5f4dcc3b5aa765d61d8327deb882cf99");
-// MD5 encoded password for reading (set null for public wiki)
+// Hashed password for editing (default',password)
+define('EDITCODE',"\$2y\$10\$r6OE5vLrPtnjvLZ2l8vFnO9JySb5TlwWLWZE6xTvWB9h8tUdVSsvK");
+// Hashed encoded password for reading (set null for public wiki)
 define('VIEWCODE',null);
 // Main theme color
 define('COLOR',"#4CAF50");

--- a/settings.php
+++ b/settings.php
@@ -20,8 +20,11 @@ $g_act=($_GET['act'] ?? '');
 // store action
 if($g_act=="store"){
   // sed codes
-  $EDITCODE=($_POST['editcode']===EDITCODE?EDITCODE:md5($_POST['editcode']));
-  $VIEWCODE=($_POST['viewcode']===VIEWCODE?VIEWCODE:(strlen($_POST['viewcode'])?md5($_POST['viewcode']):null));
+  $EDITCODE=($_POST['editcode']===EDITCODE?EDITCODE:password_hash($_POST['editcode'],PASSWORD_DEFAULT));
+  $VIEWCODE=($_POST['viewcode']===VIEWCODE?VIEWCODE:(strlen($_POST['viewcode'])?password_hash($_POST['viewcode'],PASSWORD_DEFAULT):null));
+  // replace $ with \$ for exporting as php code (with just $ it would be interpreted as variable)
+  $EDITCODE=str_replace("$", "\\$", $EDITCODE);
+  if($VIEWCODE!=null)$VIEWCODE=str_replace("$", "\\$", $VIEWCODE);
   // build configuration file
   $config="<?php\n";
   $config.="define('DEBUGGABLE',".(DEBUGGABLE?"true":"false").");\n";

--- a/setup.php
+++ b/setup.php
@@ -52,7 +52,7 @@ if($g_act=="conclude"){
 	$config.="define('OWNER',\"".$_SESSION['wikidocs']['setup']['owner']."\");\n";
 	$config.="define('NOTICE',\"".$_SESSION['wikidocs']['setup']['notice']."\");\n";
 	$config.="define('PRIVACY',null);\n";
-	$config.="define('EDITCODE',\"".md5($_SESSION['wikidocs']['setup']['editcode'])."\");\n";
+	$config.="define('EDITCODE',\"".str_replace("$", "\\$", password_hash($_SESSION['wikidocs']['setup']['editcode'],PASSWORD_DEFAULT))."\");\n";
 	$config.="define('VIEWCODE',null);\n";
 	$config.="define('COLOR',\"#4CAF50\");\n";
 	$config.="define('DARK',false);\n";

--- a/submit.php
+++ b/submit.php
@@ -47,7 +47,14 @@ function authentication(){
 	$p_document=strtolower($_POST['document']);
 	$p_password=$_POST['password'];
 	// check edit code
-	if(strtolower(md5($p_password))===strtolower(EDITCODE)){
+	if(strlen(EDITCODE)==32&&strtolower(md5($p_password))===strtolower(EDITCODE)) {
+		//TODO: update password hash in datasets/config.inc.php to password_hash() output
+		// update session
+		$_SESSION['wikidocs']['authenticated']=2;
+		// alert and redirect
+		wdf_alert($TXT->SubmitAuthSuccess,"success");
+		wdf_redirect(PATH.$p_document);
+	}else if(password_verify($p_password, EDITCODE)){
 		// update session
 		$_SESSION['wikidocs']['authenticated']=2;
 		// alert and redirect
@@ -55,7 +62,14 @@ function authentication(){
 		wdf_redirect(PATH.$p_document);
 	}
 	// check view code
-	if(strtolower(md5($p_password))===strtolower(VIEWCODE)){
+	if(strlen(VIEWCODE)==32&&strtolower(md5($p_password))===strtolower(VIEWCODE)) {
+		//TODO: update password hash in datasets/config.inc.php to password_hash() output
+		// update session
+		$_SESSION['wikidocs']['authenticated']=1;
+		// alert and redirect
+		wdf_alert($TXT->SubmitAuthSuccess,"success");
+		wdf_redirect(PATH.$p_document);
+	}else if(password_verify($p_password, VIEWCODE)){
 		// update session
 		$_SESSION['wikidocs']['authenticated']=1;
 		// alert and redirect


### PR DESCRIPTION
Issue: #118 

This changes the use of `md5()` for password hashes to `password_hash()` and `password_verify()` to use PHP's configured default hashing algorithm instead. 

The changes work with currently configured MD5 password hashes in `datasets/config.inc.php` by checking the hash length which is 32 for MD5 and a minimum of 60 for password_hash(). A code update without changes to the current configuration is thus possible.

Please note that due to the use of php code to define the hashes in the config file the dollar chars `$` in the password_hash's output must be escaped to avoid in-string variable processing.

**CAUTION!** I did only test basic functionality after installing these changes: 
- Authenticating with MD5 configured
- Setting a new edit code
- Setting a view code
- Re-authenticating with view and edit codes

I'm not sure I caught all possible situations!