### PR TITLE
Update Document.class.php

### DIFF
--- a/classes/Document.class.php
+++ b/classes/Document.class.php
@@ -206,7 +206,7 @@ final class Document{
 				// make element
 				$attachment=new stdClass();
 				$attachment->label=$element_fe;
-				$attachment->url=substr(URL,0,-1).$this->PATH."/".$element_fe;
+				$attachment->url=PATH."datasets/documents/".$this->ID."/".$element_fe;
 				// add element to documents array
 				$attachments_array[]=$attachment;
 			}

--- a/template.inc.php
+++ b/template.inc.php
@@ -115,6 +115,9 @@
         if($DOC->ID=="homepage"){
           echo $APP->TITLE;
         }else{
+          // Home Url
+          $link_address21 = PATH;
+          echo "<a href='".$link_address21. "'>Δ Home</a> / ";
           foreach($DOC->hierarchy() as $element){
             // check for current document
             if($DOC->ID==$element->path){

--- a/template.inc.php
+++ b/template.inc.php
@@ -380,7 +380,7 @@
   function new_document(){
     var new_path=prompt("<?= str_replace(["'",'"'],"\'",$TXT->PromptNewDocument) ?>",DOC.ID+"/");
     if(new_path!==DOC.ID+"/"){
-      new_path=new_path.replace(" ","-").toLowerCase()+"?edit";
+      new_path=new_path.replace(/\s+/g,'-').toLowerCase()+"?edit";
       window.location.href=APP.URL+new_path;
     }
   }


### PR DESCRIPTION
# URL Solve 

Solve attachments url error, #104 when wikidocs is hosted on subfolder (example.com/wikidocs).

Change Line 209 on Document.class.php

From `$attachment->url=substr(URL,0,-1).$this->PATH."/".$element_fe;` 

that cause error duplicate sub-folder **wikidocs/wikidocs/** name on url, when we try to open pdf file 

- https://example.com/wikidocs/wikidocs/datasets/documents/ficheiros/pdf.pdf

To `$attachment->url=PATH."datasets/documents/".$this->ID."/".$element_fe;`

- https://example.com/wikidocs/datasets/documents/ficheiros/pdf.pdf

# Add useful home link

Add **home** shortcut to main header, to better preformance on navigation.

Add next code after }else{ line 117.

```
          // Home Url
          $link_address21 = PATH;
          echo "<a href='".$link_address21. "'>Δ Home</a> / "; 
```
**- From:**  

![image](https://github.com/user-attachments/assets/6ef66b48-658c-4381-bbd7-79765ead1d5c)

**- To:**

![image](https://github.com/user-attachments/assets/f3b9215d-8ede-4f5f-ab7f-fc57c31cde40)

