### PR TITLE
Document output sanitization and path checks

### DIFF
--- a/classes/Document.class.php
+++ b/classes/Document.class.php
@@ -74,11 +74,12 @@ final class Document{
 	protected ?string $FILE;
 	protected ?int $TIMESTAMP;
 
-	/**
-	 * Constructor
-	 *
-	 * @param string $id Document ID (examples: homepage, samples/typography )
-	 */
+    /**
+     * Constructor
+     *
+     * @param string $id Document ID (examples: homepage, samples/typography )
+     * @throws Exception
+     */
 	public function __construct(string $id){
 		// definitions
 		$this->ID=$id;
@@ -92,6 +93,11 @@ final class Document{
 		// check if file exist
 		if(!file_exists($this->FILE)){$this->FILE=null;}
 		if(file_exists($this->FILE ?? '')){$this->TIMESTAMP=filemtime($this->FILE);}
+
+        if (substr_count($this->ID, "..") > 0 ||
+            substr_count($this->ID, ':') > 0 || strpos($this->ID, '/') == 0) { // These 2 checks are to detect when the user uses a windows or unix absolute path; I'm not sure they are necessary, but they shouldn't do any harm either.
+            throw new Exception("The user is probably trying to create the document outside of the documents dataset"); // TODO: handle the error gracefully.
+        }
 	}
 
 	/**


### PR DESCRIPTION
2 fixes:

- Sanitized dangerous html in the documents (script tags and html events);
- Added check to prevent the user from creating documents outside of the dataset/documents/ folder.