### PR TITLE
Enter edit mode when 'e' is pressed

### DIFF
--- a/template.inc.php
+++ b/template.inc.php
@@ -44,7 +44,7 @@
   <?php if(MODE=="view"): ?>
     <script>
       function onDocumentKeyDown(e) {
-        if(e.key = 'e') {
+        if(e.key == 'e') {
           window.open(window.location.href + "?edit", target = "_self");
         }
       }

--- a/template.inc.php
+++ b/template.inc.php
@@ -41,6 +41,16 @@
       gtag('config','<?= GTAG ?>');
     </script>
   <?php endif; ?>
+  <?php if(MODE=="view"): ?>
+    <script>
+      function onDocumentKeyDown(e) {
+        if(e.key = 'e') {
+          window.open(window.location.href + "?edit", target = "_self");
+        }
+      }
+      document.onkeydown = onDocumentKeyDown;
+  </script>
+<?php endif; ?>
 </head>
 <body>
 <header>


### PR DESCRIPTION
Call it bad habit - but I'm used to press "e" on my keyboard to enter the edit mode of the viewed document.

This change adds a small onkeypress handler for the view mode which calls the edit URL whenever the user presses the e key.

Not logged in users will receive the login screen in that case - thats already covered by WikiDocs.