### PR TITLE
Add document version management

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -337,7 +337,9 @@ attachments, child document directories, and `_versions`. A directory without `c
 │         ├── content.md                  │
 │         ├── map.jpg                     │
 │         ├── milan/                      │
-│         └── rome/                       │
+│         ├── rome/                       │
+│         └── _versions/                  │
+│             └── 1780000000000.md        │
 └─────────────────────────────────────────┘
 ```
 
@@ -358,7 +360,11 @@ This is the document body.
 ```
 
 On store, the backend assigns the current timestamp, fills a missing title from the final path segment, fills a missing
-author from the session token, and defaults missing tags to an empty array.
+author from the session token, and defaults missing tags to an empty array. When the optional `versioning` request flag
+is `true` and `content.md` already exists, the backend first copies the current file to
+`_versions/<unixTimestampMilliseconds>.md`. The snapshot copy must succeed before the document is overwritten; a failed
+copy fails the store operation. New documents never create a version. `_versions` is an internal archive and is not
+exposed through document APIs.
 
 ```
 ┌─────────────────────────────────────────┐
@@ -385,7 +391,8 @@ author from the session token, and defaults missing tags to an empty array.
 │ ContentContract                         │
 ├─────────────────────────────────────────┤
 │ Properties:                             │
-│ └── raw: string                         │
+│ ├── raw: string                         │
+│ └── versioning?: boolean                 │
 └─────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────┐

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,7 @@ The codebase is organized into a small set of top-level contexts:
 
 - dataset — the on-disk collection of wiki pages the engine serves (directory pointed at by `DATASETS`).
 - document / page — a single wiki page within a dataset; stored as a file containing frontmatter + body.
+- version snapshot — a pre-save copy of an existing document's `content.md`, stored internally under its `_versions` directory.
 - trash entry — a deleted document node retained in the dataset's trash.
 - contract — a type definition in `shared/contracts` used across layers.
 - artifact — build outputs (frontend bundles, desktop packages) — not part of the dataset.

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ _Please consider supporting this project by making a donation via [PayPal](https
 - Editor full WYSIWYG
 - Support for KaTeX math
 - Support for Mermaid diagrams
-- ~~Unlimited page revisions~~
+- Unlimited page revisions
 - Uploading and downloading Attachments
 - Uploading images ~~(also from clipboard)~~
 - Content can be categorized in namespaces
 - ~~Automatic generated index and sitemap~~
 - Public and private browsing
+- Desktop and remote Sync
 - Syntax highlighting
 - ~~Multi-language~~
 - ~~Dark mode~~
 - ~~Sitemap~~
-- Sync
 - and many more...
 
 ~~Striked~~ features are work in progress.

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -286,6 +286,34 @@ export class AppController {
     return this.documentService.document_remove(path);
   }
 
+  @ApiBearerAuth()
+  @Authorizations('write')
+  @Get('version')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Retrieve a document version' })
+  @ApiQuery({ name: 'path', required: true })
+  @ApiQuery({ name: 'timestamp', required: true })
+  version_retrieve(
+    @Query('path') path:string,
+    @Query('timestamp') timestamp:string
+  ):Promise<ContentSchema> {
+    return this.documentService.version_retrieve(path, timestamp);
+  }
+
+  @ApiBearerAuth()
+  @Authorizations('delete')
+  @Delete('version')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Remove a document version' })
+  @ApiQuery({ name: 'path', required: true })
+  @ApiQuery({ name: 'timestamp', required: true })
+  version_remove(
+    @Query('path') path:string,
+    @Query('timestamp') timestamp:string
+  ):Promise<void> {
+    return this.documentService.version_remove(path, timestamp);
+  }
+
   @Public()
   @Get('attachment')
   @HttpCode(200)

--- a/backend/src/schemas/content.schema.ts
+++ b/backend/src/schemas/content.schema.ts
@@ -1,6 +1,6 @@
 import { Expose } from "class-transformer";
-import { IsNotEmpty, IsString } from "class-validator";
-import { ApiProperty } from "@nestjs/swagger";
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from "class-validator";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { ContentContract } from "@shared/contracts";
 
 export class ContentSchema implements ContentContract {
@@ -10,5 +10,11 @@ export class ContentSchema implements ContentContract {
   @IsNotEmpty()
   @ApiProperty({ example: 'Document source code' })
   raw:string;
+
+  @Expose()
+  @IsBoolean()
+  @IsOptional()
+  @ApiPropertyOptional({ example: true, description: 'Create a snapshot before overwriting an existing document.' })
+  versioning?:boolean;
 
 }

--- a/backend/src/schemas/document.schema.ts
+++ b/backend/src/schemas/document.schema.ts
@@ -31,6 +31,10 @@ export class DocumentSchema implements DocumentContract {
   attachments:AttachmentSchema[];
 
   @Expose()
+  @ApiProperty({ type: [ String ], example: [ '1750000000000' ] })
+  versions:string[];
+
+  @Expose()
   @Type(() => ContentSchema)
   @ApiProperty({ type: () => ContentSchema })
   content:ContentSchema;

--- a/backend/src/services/document.service.ts
+++ b/backend/src/services/document.service.ts
@@ -3,7 +3,7 @@ import { basename, join } from "node:path";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { createInterface, Interface } from "node:readline";
 import { constants, createReadStream, Dirent, ReadStream, Stats } from "node:fs";
-import { access, mkdir, readdir, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { access, copyFile, mkdir, readdir, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import {
   BadRequestException,
   ConflictException,
@@ -263,6 +263,15 @@ export class DocumentService {
       await access(directoryPath, constants.W_OK);
       const documentStats:Stats | null = await stat(documentPath).catch(():null => null);
       if ( documentStats?.isFile() ) { await access(documentPath, constants.W_OK); }
+      if ( content.versioning === true && documentStats?.isFile() ) {
+        const versionsDirectoryPath:string = join(directoryPath, EnvironmentService.VERSIONS_DIRECTORY);
+        const versionPath:string = join(versionsDirectoryPath, `${ Date.now() }.md`);
+        await mkdir(versionsDirectoryPath, { recursive: true });
+        await access(versionsDirectoryPath, constants.W_OK);
+        await access(documentPath, constants.R_OK);
+        await copyFile(documentPath, versionPath);
+        this.logger.debug(`Document <${ documentPath }> versioned to <${ versionPath }>`);
+      }
       const { data, content: body } = matter(content.raw.replace(/\r\n?/g, '\n'));
       if ( ! data.title || typeof data.title !== 'string' || ! data.title.trim() ) {
         const heading:RegExpMatchArray | null = body.match(/^#\s+(.+)$/m);

--- a/backend/src/services/document.service.ts
+++ b/backend/src/services/document.service.ts
@@ -232,6 +232,46 @@ export class DocumentService {
     }
   }
 
+  private getVersionPath(path:string, timestamp:string):string {
+    if ( ! /^(?:0|[1-9]\d*)$/.test(timestamp) ) {
+      throw new NotFoundException(`Version <${ timestamp }> not found`);
+    }
+    const sanitizedPath:string = this.environmentService.sanitizeDocumentPath(path);
+    return join(
+      this.environmentService.getDocumentDirectoryPath(sanitizedPath),
+      EnvironmentService.VERSIONS_DIRECTORY,
+      `${ timestamp }.md`
+    );
+  }
+
+  private async retrieveVersions(path:string):Promise<string[]> {
+    const sanitizedPath:string = this.environmentService.sanitizeDocumentPath(path);
+    const versionsDirectoryPath:string = join(
+      this.environmentService.getDocumentDirectoryPath(sanitizedPath),
+      EnvironmentService.VERSIONS_DIRECTORY
+    );
+    let entries:Dirent[];
+    try {
+      entries = await readdir(versionsDirectoryPath, { withFileTypes: true });
+    } catch ( error ) {
+      const code:string | undefined = ( error as NodeJS.ErrnoException )?.code;
+      if ( code === 'ENOENT' ) { return []; }
+      this.handleFsError(error);
+    }
+    const timestamps:string[] = [];
+    for ( const entry of entries ) {
+      const match:RegExpMatchArray | null = ( entry.isFile() ? entry.name.match(/^(0|[1-9]\d*)\.md$/) : null );
+      if ( ! match ) {
+        console.warn(`Ignoring invalid document version entry <${ entry.name }> for <${ sanitizedPath }>`);
+        continue;
+      }
+      timestamps.push(match[ 1 ]);
+    }
+    return timestamps.sort((first:string, second:string):number => (
+      second.length - first.length || second.localeCompare(first)
+    ));
+  }
+
   public async tree(path:string):Promise<TreeSchema> {
     const sanitizedPath:string = this.environmentService.sanitizeDocumentPath(path);
     if ( ! await this.checkIfDirectoryExists(path) ) {
@@ -249,9 +289,10 @@ export class DocumentService {
     const metadata:MetadataSchema = await this.buildDocumentMetadata(path);
     const children:MetadataSchema[] = ( exists ? await this.retriveChildren(path) : [] );
     const attachments:AttachmentSchema[] = ( exists ? await this.retrieveAttachments(path) : [] );
+    const versions:string[] = ( exists ? await this.retrieveVersions(path) : [] );
     const content:ContentSchema = ( exists ? await this.loadDocumentFullContent(path) : { raw: '' } );
     this.logger.debug(`Document <${ path }> ${ exists ? 'retrieved' : 'not exists' }`);
-    return { exists, pinned, metadata, children, attachments, content };
+    return { exists, pinned, metadata, children, attachments, versions, content };
   }
 
   public async document_store(path:string, token:TokenSchema, content:ContentSchema):Promise<void> {
@@ -318,12 +359,6 @@ export class DocumentService {
     }
   }
 
-  public async document_remove(path:string, allowRoot:boolean = false, recursive:boolean = true):Promise<void> {
-    const sanitizedPath:string = this.environmentService.sanitizeDocumentPath(path);
-    if ( ! sanitizedPath && ! allowRoot ) { throw new BadRequestException(`Root document cannot be deleted`); }
-    await this.moveDocumentToTrash(sanitizedPath, recursive);
-  }
-
   private async moveDocumentToTrash(sanitizedPath:string, recursive:boolean):Promise<void> {
     const trashRoot:string = this.environmentService.getTrashRoot();
     const sourceDirectoryName:string = ( sanitizedPath ? basename(sanitizedPath) : 'index' );
@@ -353,6 +388,36 @@ export class DocumentService {
       }
       this.logger.debug(`Document <${ sourceDirectoryPath }> removed to <${ destinationDirectoryPath }>`);
     } catch ( error ) {
+      this.handleFsError(error);
+    }
+  }
+
+  public async document_remove(path:string, allowRoot:boolean = false, recursive:boolean = true):Promise<void> {
+    const sanitizedPath:string = this.environmentService.sanitizeDocumentPath(path);
+    if ( ! sanitizedPath && ! allowRoot ) { throw new BadRequestException(`Root document cannot be deleted`); }
+    await this.moveDocumentToTrash(sanitizedPath, recursive);
+  }
+
+  public async version_retrieve(path:string, timestamp:string):Promise<ContentSchema> {
+    const versionPath:string = this.getVersionPath(path, timestamp);
+    try {
+      const raw:string = await readFile(versionPath, 'utf-8');
+      return { raw: raw.replace(/\r\n?/g, '\n') };
+    } catch ( error ) {
+      const code:string | undefined = ( error as NodeJS.ErrnoException )?.code;
+      if ( code === 'ENOENT' ) { throw new NotFoundException(`Version <${ timestamp }> not found`); }
+      this.handleFsError(error);
+    }
+  }
+
+  public async version_remove(path:string, timestamp:string):Promise<void> {
+    const versionPath:string = this.getVersionPath(path, timestamp);
+    try {
+      await unlink(versionPath);
+      this.logger.debug(`Document version <${ versionPath }> removed`);
+    } catch ( error ) {
+      const code:string | undefined = ( error as NodeJS.ErrnoException )?.code;
+      if ( code === 'ENOENT' ) { throw new NotFoundException(`Version <${ timestamp }> not found`); }
       this.handleFsError(error);
     }
   }

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -33,7 +33,10 @@ import {
   StartupComponent,
   TopComponent,
   TreeComponent,
-  TreeData
+  TreeData,
+  VersionsComponent,
+  VersionsDialogData,
+  VersionsDialogResult
 } from 'src/app/components';
 
 @Component({
@@ -146,6 +149,16 @@ export class App implements AfterViewInit {
       && ( this.currentDocument()?.exists ?? false );
   });
 
+  protected readonly canOpenVersions:Signal<boolean> = computed(():boolean => {
+    const document:DocumentType | null = this.currentDocument();
+    return this.mode() === 'edit'
+      && ! this.isSavingDocument()
+      && ! this.isEditorDirty()
+      && this.hasWriteAuthorization()
+      && document?.exists === true
+      && document.versions.length > 0;
+  });
+
   protected readonly isEditorDirty:Signal<boolean> = computed(():boolean => this.editorRaw() !== this.editorInitialRaw());
 
   protected readonly canSaveDocument:Signal<boolean> = computed(():boolean => {
@@ -216,18 +229,19 @@ export class App implements AfterViewInit {
 
   protected readonly editActions:Signal<ReadonlyArray<ActionItem>> = computed<ReadonlyArray<ActionItem>>(():ActionItem[] => [
     this.createAction('cancel', 'cancel', 'Cancel editing', this.isSavingDocument(), 'grey'),
+    this.createAction('versions', 'history', 'Document versions', ! this.canOpenVersions(), 'yellow'),
     this.createAction(
       'versioning',
       this.versioning() ? 'check_box' : 'check_box_outline_blank',
       this.versioning() ? 'Create version before saving' : 'Do not create version before saving',
       this.isSavingDocument() || this.currentDocument()?.exists !== true,
-      'yellow'
+      'orange'
     ),
     ...( this.hasWriteAuthorization()
-      ? [ this.createAction('move', 'drive_file_move', 'Move document', ! this.canMoveDocument(), 'blue') ]
+      ? [ this.createAction('attachments', 'attach_file', 'Attachments', ! this.canOpenAttachments(), 'blue') ]
       : [] ),
     ...( this.hasWriteAuthorization()
-      ? [ this.createAction('attachments', 'attach_file', 'Attachments', ! this.canOpenAttachments(), 'purple') ]
+      ? [ this.createAction('move', 'drive_file_move', 'Move document', ! this.canMoveDocument(), 'purple') ]
       : [] ),
     ...( this.hasDeleteAuthorization()
       ? [ this.createAction('delete', 'delete', 'Delete document', ! this.canDeleteDocument(), 'red') ]
@@ -284,6 +298,27 @@ export class App implements AfterViewInit {
         if ( ! result ) { return; }
         this.syncCurrentDocumentAttachments(result.attachments);
         if ( result.markdown ) { this.queueEditorInsertRequest(result.markdown); }
+      });
+  }
+
+  private openVersionsDialog():void {
+    if ( ! this.canOpenVersions() ) { return; }
+    const document:DocumentType | null = this.currentDocument();
+    if ( ! document ) { return; }
+    const data:VersionsDialogData = {
+      path: this.currentPath(),
+      versions: [ ...document.versions ],
+      canDelete: this.hasDeleteAuthorization(),
+    };
+    this.dialog
+      .open(VersionsComponent, { width: '90vw', maxWidth: '640px', disableClose: true, data })
+      .afterClosed()
+      .subscribe((result:VersionsDialogResult | undefined):void => {
+        if ( ! result ) { return; }
+        this.currentDocument.update((current:DocumentType | null):DocumentType | null => {
+          return ( current ? { ...current, versions: [ ...result.versions ] } : null );
+        });
+        if ( result.raw !== null ) { this.setEditorRaw(result.raw); }
       });
   }
 
@@ -719,6 +754,7 @@ export class App implements AfterViewInit {
     if ( action.key === 'edit' ) { return this.startEditing(); }
     if ( action.key === 'cancel' ) { return this.cancelEditing(); }
     if ( action.key === 'versioning' ) { return this.versioning.update((enabled:boolean):boolean => ! enabled); }
+    if ( action.key === 'versions' ) { return this.openVersionsDialog(); }
     if ( action.key === 'attachments' ) { return this.openAttachmentsDialog(); }
     if ( action.key === 'move' ) { return this.openMoveDialog(); }
     if ( action.key === 'delete' ) { return this.deleteDocument(); }

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -104,6 +104,8 @@ export class App implements AfterViewInit {
 
   protected readonly editorInitialRaw:WritableSignal<string> = signal('');
 
+  protected readonly versioning:WritableSignal<boolean> = signal(false);
+
   protected readonly pendingEditorInsertRequest:WritableSignal<EditorInsertRequest | null> = signal<EditorInsertRequest | null>(null);
 
   protected readonly isSavingDocument:WritableSignal<boolean> = signal(false);
@@ -214,14 +216,21 @@ export class App implements AfterViewInit {
 
   protected readonly editActions:Signal<ReadonlyArray<ActionItem>> = computed<ReadonlyArray<ActionItem>>(():ActionItem[] => [
     this.createAction('cancel', 'cancel', 'Cancel editing', this.isSavingDocument(), 'grey'),
-    ...( this.canMoveDocument()
-      ? [ this.createAction('move', 'drive_file_move', 'Move document', false, 'blue') ]
+    this.createAction(
+      'versioning',
+      this.versioning() ? 'check_box' : 'check_box_outline_blank',
+      this.versioning() ? 'Create version before saving' : 'Do not create version before saving',
+      this.isSavingDocument() || this.currentDocument()?.exists !== true,
+      'yellow'
+    ),
+    ...( this.hasWriteAuthorization()
+      ? [ this.createAction('move', 'drive_file_move', 'Move document', ! this.canMoveDocument(), 'blue') ]
       : [] ),
-    ...( this.canOpenAttachments()
-      ? [ this.createAction('attachments', 'attach_file', 'Attachments', false, 'purple') ]
+    ...( this.hasWriteAuthorization()
+      ? [ this.createAction('attachments', 'attach_file', 'Attachments', ! this.canOpenAttachments(), 'purple') ]
       : [] ),
-    ...( this.canDeleteDocument()
-      ? [ this.createAction('delete', 'delete', 'Delete document', false, 'red') ]
+    ...( this.hasDeleteAuthorization()
+      ? [ this.createAction('delete', 'delete', 'Delete document', ! this.canDeleteDocument(), 'red') ]
       : [] ),
     this.createAction('save', 'save', 'Save', ! this.canSaveDocument()),
   ]);
@@ -361,6 +370,7 @@ export class App implements AfterViewInit {
     const raw:string = ( document.content?.raw ?? '' );
     this.editorInitialRaw.set(raw);
     this.setEditorRaw(raw);
+    this.versioning.set(document.exists);
     this.mode.set('edit');
   }
 
@@ -425,7 +435,10 @@ export class App implements AfterViewInit {
   private saveDocument():void {
     if ( ! this.canSaveDocument() ) { return; }
     this.isSavingDocument.set(true);
-    this.httpService.POST<void>(`/document?path=${ encodeURIComponent(this.currentPath()) }`, { raw: this.editorRaw() }).subscribe({
+    this.httpService.POST<void>(`/document?path=${ encodeURIComponent(this.currentPath()) }`, {
+      raw: this.editorRaw(),
+      versioning: this.versioning()
+    }).subscribe({
       next: ():void => {
         this.mode.set('view');
         this.isSavingDocument.set(false);
@@ -705,6 +718,7 @@ export class App implements AfterViewInit {
     if ( action.key === 'new' ) { return this.startAddingPage(); }
     if ( action.key === 'edit' ) { return this.startEditing(); }
     if ( action.key === 'cancel' ) { return this.cancelEditing(); }
+    if ( action.key === 'versioning' ) { return this.versioning.update((enabled:boolean):boolean => ! enabled); }
     if ( action.key === 'attachments' ) { return this.openAttachmentsDialog(); }
     if ( action.key === 'move' ) { return this.openMoveDialog(); }
     if ( action.key === 'delete' ) { return this.deleteDocument(); }

--- a/frontend/src/app/components/header/action/action.component.html
+++ b/frontend/src/app/components/header/action/action.component.html
@@ -4,6 +4,7 @@
   [class.action-button-grey]="action().variant === 'grey'"
   [class.action-button-red]="action().variant === 'red'"
   [class.action-button-yellow]="action().variant === 'yellow'"
+  [class.action-button-orange]="action().variant === 'orange'"
   [class.action-button-blue]="action().variant === 'blue'"
   [class.action-button-purple]="action().variant === 'purple'"
   [attr.aria-label]="action().tooltip"

--- a/frontend/src/app/components/header/action/action.component.scss
+++ b/frontend/src/app/components/header/action/action.component.scss
@@ -10,6 +10,11 @@
 .action-button {
   background-color: var(--theme-color);
   color: #ffffff;
+
+  &:disabled {
+    filter: saturate(0.5);
+    opacity: 0.5;
+  }
 }
 
 .action-button-grey {

--- a/frontend/src/app/components/header/action/action.component.scss
+++ b/frontend/src/app/components/header/action/action.component.scss
@@ -32,6 +32,11 @@
   color: #ffffff;
 }
 
+.action-button-orange {
+  background-color: #fb8c00;
+  color: #ffffff;
+}
+
 .action-button-blue {
   background-color: #0288d1;
   color: #ffffff;

--- a/frontend/src/app/components/header/action/action.component.ts
+++ b/frontend/src/app/components/header/action/action.component.ts
@@ -8,7 +8,7 @@ export type ActionItem = {
   readonly icon:string;
   readonly tooltip:string;
   readonly disabled?:boolean;
-  readonly variant?:'default' | 'grey' | 'red' | 'yellow' | 'blue' | 'purple';
+  readonly variant?:'default' | 'grey' | 'red' | 'yellow' | 'orange' | 'blue' | 'purple';
 };
 
 @Component({

--- a/frontend/src/app/components/index.ts
+++ b/frontend/src/app/components/index.ts
@@ -22,4 +22,5 @@ export * from 'src/app/components/startup/startup.component';
 export * from 'src/app/components/top/top.component';
 export * from 'src/app/components/trash/trash.component';
 export * from 'src/app/components/tree/tree.component';
+export * from 'src/app/components/versions/versions.component';
 export * from 'src/app/components/wait/wait.component';

--- a/frontend/src/app/components/versions/versions.component.html
+++ b/frontend/src/app/components/versions/versions.component.html
@@ -1,0 +1,31 @@
+<h2 mat-dialog-title class="dialog-title">
+  <span>Document versions</span>
+  <button mat-icon-button type="button" class="dialog-close-button" [disabled]="isLoading() || deletingTimestamp() !== null" (click)="close()" aria-label="Close versions dialog">
+    <mat-icon>close</mat-icon>
+  </button>
+</h2>
+<mat-dialog-content class="dialog-content">
+  @if (isLoading()) {
+    <mat-progress-bar mode="indeterminate"/>
+  }
+  @if (versions().length === 0) {
+    <p class="empty-message">No versions available for this document.</p>
+  } @else {
+    <mat-list>
+      @for (timestamp of versions(); track timestamp) {
+        <mat-list-item class="version-list-item">
+          <div class="version-row">
+            <button mat-button color="primary" type="button" [disabled]="isLoading() || deletingTimestamp() !== null" (click)="loadVersion(timestamp)">
+              {{ formatTimestamp(timestamp) }}
+            </button>
+            @if (data.canDelete) {
+              <button mat-icon-button color="warn" type="button" [disabled]="isLoading() || deletingTimestamp() !== null" (click)="requestDeleteVersion(timestamp)" aria-label="Delete version">
+                <mat-icon>delete</mat-icon>
+              </button>
+            }
+          </div>
+        </mat-list-item>
+      }
+    </mat-list>
+  }
+</mat-dialog-content>

--- a/frontend/src/app/components/versions/versions.component.scss
+++ b/frontend/src/app/components/versions/versions.component.scss
@@ -1,0 +1,31 @@
+.dialog-title {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  text-align: left;
+  margin-bottom: 0;
+}
+
+.dialog-close-button {
+  margin-left: auto;
+  margin-right: -0.25rem;
+}
+
+.dialog-content {
+  min-width: min(520px, 92vw);
+}
+
+.version-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+:host ::ng-deep .version-list-item .mdc-list-item__content {
+  width: 100%;
+}
+
+.empty-message {
+  margin: 0.5rem 0;
+}

--- a/frontend/src/app/components/versions/versions.component.ts
+++ b/frontend/src/app/components/versions/versions.component.ts
@@ -1,0 +1,127 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, inject, signal, WritableSignal } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { map, Observable } from 'rxjs';
+import { ConfirmComponent, ConfirmData } from 'src/app/components/confirm/confirm.component';
+import { AlertService } from 'src/app/services/alert.service';
+import { HttpService } from 'src/app/services/http.service';
+import { ContentType, DocumentType } from 'src/app/types';
+
+export type VersionsDialogData = {
+  readonly path:string;
+  readonly versions:ReadonlyArray<string>;
+  readonly canDelete:boolean;
+};
+
+export type VersionsDialogResult = {
+  readonly raw:string | null;
+  readonly versions:ReadonlyArray<string>;
+};
+
+@Component({
+  standalone: true,
+  selector: 'app-versions',
+  templateUrl: './versions.component.html',
+  styleUrl: './versions.component.scss',
+  imports: [ MatDialogModule, MatButtonModule, MatIconModule, MatListModule, MatProgressBarModule ],
+})
+export class VersionsComponent {
+
+  private readonly alertService:AlertService = inject(AlertService);
+  private readonly httpService:HttpService = inject(HttpService);
+  private readonly dialog:MatDialog = inject(MatDialog);
+  private readonly dialogRef:MatDialogRef<VersionsComponent, VersionsDialogResult> = inject(MatDialogRef<VersionsComponent, VersionsDialogResult>);
+
+  protected readonly data:VersionsDialogData = inject<VersionsDialogData>(MAT_DIALOG_DATA);
+  protected readonly versions:WritableSignal<ReadonlyArray<string>> = signal<ReadonlyArray<string>>([ ...this.data.versions ]);
+  protected readonly isLoading:WritableSignal<boolean> = signal<boolean>(false);
+  protected readonly deletingTimestamp:WritableSignal<string | null> = signal<string | null>(null);
+
+  protected close():void {
+    if ( this.isLoading() || this.deletingTimestamp() !== null ) { return; }
+    this.dialogRef.close({ raw: null, versions: [ ...this.versions() ] });
+  }
+
+  protected formatTimestamp(timestamp:string):string {
+    const date:Date = new Date(Number(timestamp));
+    const pad = (value:number):string => value.toString().padStart(2, '0');
+    return `${ date.getFullYear() }-${ pad(date.getMonth() + 1) }-${ pad(date.getDate()) } ${ pad(date.getHours()) }:${ pad(date.getMinutes()) }:${ pad(date.getSeconds()) }`;
+  }
+
+  protected loadVersion(timestamp:string):void {
+    if ( this.isLoading() || this.deletingTimestamp() !== null ) { return; }
+    this.isLoading.set(true);
+    const uri:string = `/version?path=${ encodeURIComponent(this.data.path) }&timestamp=${ encodeURIComponent(timestamp) }`;
+    this.httpService.GET<ContentType>(uri).subscribe({
+      next: (content:ContentType):void => {
+        this.dialogRef.close({ raw: content.raw, versions: [ ...this.versions() ] });
+      },
+      error: (error:HttpErrorResponse):void => {
+        this.isLoading.set(false);
+        this.alertService.error(error.message || 'Unable to load the selected version.');
+        this.refreshVersions();
+      }
+    });
+  }
+
+  protected requestDeleteVersion(timestamp:string):void {
+    if ( ! this.data.canDelete || this.isLoading() || this.deletingTimestamp() !== null ) { return; }
+    const data:ConfirmData = {
+      title: 'Delete version',
+      message: `Are you sure you want to permanently delete the version from ${ this.formatTimestamp(timestamp) }?`,
+      confirmLabel: 'Delete',
+      cancelLabel: 'Cancel',
+      confirmColor: 'warn',
+    };
+    this.openConfirmDialog(data).subscribe((confirmed:boolean):void => {
+      if ( confirmed ) { this.deleteVersion(timestamp); }
+    });
+  }
+
+  protected isDeleting(timestamp:string):boolean {
+    return this.deletingTimestamp() === timestamp;
+  }
+
+  private deleteVersion(timestamp:string):void {
+    this.deletingTimestamp.set(timestamp);
+    const uri:string = `/version?path=${ encodeURIComponent(this.data.path) }&timestamp=${ encodeURIComponent(timestamp) }`;
+    this.httpService.DELETE<void>(uri).subscribe({
+      next: ():void => {
+        this.deletingTimestamp.set(null);
+        this.alertService.success('Document version deleted successfully.');
+        this.refreshVersions();
+      },
+      error: (error:HttpErrorResponse):void => {
+        this.deletingTimestamp.set(null);
+        this.alertService.error(error.message || 'Unable to delete the selected version.');
+        this.refreshVersions();
+      }
+    });
+  }
+
+  private refreshVersions():void {
+    this.isLoading.set(true);
+    this.httpService.GET<DocumentType>(`/document?path=${ encodeURIComponent(this.data.path) }`).subscribe({
+      next: (document:DocumentType):void => {
+        this.versions.set([ ...document.versions ]);
+        this.isLoading.set(false);
+      },
+      error: (error:HttpErrorResponse):void => {
+        this.isLoading.set(false);
+        this.alertService.error(error.message || 'Unable to refresh document versions.');
+      }
+    });
+  }
+
+  private openConfirmDialog(data:ConfirmData):Observable<boolean> {
+    return this.dialog
+      .open(ConfirmComponent, { width: '90vw', maxWidth: '520px', data })
+      .afterClosed()
+      .pipe(map((confirmed:boolean | undefined):boolean => confirmed === true));
+  }
+
+}

--- a/frontend/src/app/types/content.type.ts
+++ b/frontend/src/app/types/content.type.ts
@@ -2,6 +2,7 @@ import type { ContentContract } from '@shared/contracts';
 
 export type ContentType = {
   raw:string;
+  versioning?:boolean;
 };
 
 type ContentShapeGuard = [ ContentContract ] extends [ ContentType ]

--- a/frontend/src/app/types/document.type.ts
+++ b/frontend/src/app/types/document.type.ts
@@ -9,6 +9,7 @@ export type DocumentType = {
   metadata:MetadataType;
   children:MetadataType[];
   attachments:AttachmentType[];
+  versions:string[];
   content:ContentType;
 };
 

--- a/shared/contracts/content.contract.ts
+++ b/shared/contracts/content.contract.ts
@@ -1,3 +1,4 @@
 export type ContentContract = {
   raw:string;
+  versioning?:boolean;
 };

--- a/shared/contracts/document.contract.ts
+++ b/shared/contracts/document.contract.ts
@@ -8,5 +8,6 @@ export type DocumentContract = {
   metadata:MetadataContract;
   children:MetadataContract[];
   attachments:AttachmentContract[];
+  versions:string[];
   content:ContentContract;
 };


### PR DESCRIPTION
### Summary

This PR introduces document versioning across the backend, shared contracts, and frontend.

- Adds an optional `versioning` flag to document content, allowing a snapshot to be created before an existing document is overwritten.
- Stores snapshots as timestamped Markdown files in each document’s versions directory.
- Includes available version timestamps in the document response.
- Adds authenticated API endpoints to retrieve and permanently delete a specific document version.
- Adds a frontend version-management dialog where users can load a previous version or, with delete permission, remove it.
- Adds edit-mode actions to enable or disable snapshot creation before saving.
- Updates contracts and documentation to reflect the new versioning behavior.

#### Permissions

- Retrieving a version requires `write` authorization.
- Deleting a version requires `delete` authorization.