### PR TITLE
Add version check to Makefile for release consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,23 @@
 # Wiki|Docs Makefile
 #
 
-VERSION := $(strip $(shell cat VERSION 2>/dev/null))
-#BEV = $(shell jq -r .version backend/package.json)
-#FEV = $(shell jq -r .version frontend/package.json)
-#DV = $(shell jq -r .version desktop/package.json)
-# @todo check if all versions is equals
+VERSION := $(strip $(shell jq -Rr . VERSION))
+BEV := $(strip $(shell jq -r .version backend/package.json))
+FEV := $(strip $(shell jq -r .version frontend/package.json))
+DV := $(strip $(shell jq -r .version desktop/package.json))
 
-.PHONY: install-deps build-runtime desktop-release docker-compose-up docker-compose-down docker-release docker-release-beta
+.PHONY: check-versions install-deps build-runtime desktop-release docker-compose-up docker-compose-down docker-release docker-release-beta
+
+check-versions:
+	@if ! jq -en \
+		--arg version "$(VERSION)" \
+		--arg backend "$(BEV)" \
+		--arg frontend "$(FEV)" \
+		--arg desktop "$(DV)" \
+		'$$version == $$backend and $$version == $$frontend and $$version == $$desktop' > /dev/null; then \
+		echo "Version mismatch: VERSION=$(VERSION), backend=$(BEV), frontend=$(FEV), desktop=$(DV)" >&2; \
+		exit 1; \
+	fi
 
 install-deps:
 	cd backend && npm i
@@ -19,7 +29,7 @@ build-runtime:
 	cd backend && npm run build
 	cd frontend && npm run build
 
-desktop-release:
+desktop-release: check-versions
 	@echo "Release Wiki|Docs Desktop version $(VERSION)"
 	cd desktop && npm run make
 
@@ -32,11 +42,11 @@ docker-compose-down:
 	docker compose -f docker/compose.yml -p wikidocs-dev down
 	docker compose -f docker/compose.yml -p wikidocs-dev rm -f
 
-docker-release:
+docker-release: check-versions
 	@echo "Releasing Wiki|Docs version $(VERSION)"
 	#docker build -f docker/dockerfile -t zavy86/wikidocs:$(VERSION) .
 	docker buildx build --platform linux/amd64,linux/arm64 -f docker/dockerfile -t zavy86/wikidocs:$(VERSION) .
 
-docker-release-beta:
+docker-release-beta: check-versions
 	@echo "Releasing Wiki|Docs beta version"
 	docker buildx build --platform linux/amd64,linux/arm64 -f docker/dockerfile -t zavy86/wikidocs:beta --push .


### PR DESCRIPTION
This pull request updates the `Makefile` to improve version consistency and automation for release processes. The main changes ensure that the top-level `VERSION` matches the versions in all subprojects before allowing release tasks to proceed.

**Version consistency and validation:**

* Added `check-versions` target to the `Makefile` to verify that the version in the `VERSION` file matches the versions in `backend/package.json`, `frontend/package.json`, and `desktop/package.json`. If any mismatch is detected, the process fails with an error message.
* Updated the `desktop-release`, `docker-release`, and `docker-release-beta` targets to depend on `check-versions`, preventing releases if versions are not synchronized. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L22-R32) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L35-R50)

**Variable management improvements:**

* Switched to using `jq` to read and assign version variables (`VERSION`, `BEV`, `FEV`, `DV`) directly from their respective files, ensuring more robust and consistent version extraction.