### PR TITLE
Add color picker and live theme color change

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,11 @@ _Please consider supporting this project by making a donation via [PayPal](https
 - Uploading and downloading Attachments
 - Uploading images ~~(also from clipboard)~~
 - Content can be categorized in namespaces
-- ~~Automatic generated index and sitemap~~
 - Public and private browsing
 - Desktop and remote Sync
 - Syntax highlighting
 - ~~Multi-language~~
 - ~~Dark mode~~
-- ~~Sitemap~~
 - and many more...
 
 ~~Striked~~ features are work in progress.

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -11,6 +11,7 @@ import { HttpService } from 'src/app/services/http.service';
 import { InformationService } from 'src/app/services/information.service';
 import { PrivacyService } from 'src/app/services/privacy.service';
 import { AlertService } from 'src/app/services/alert.service';
+import { ThemeService } from 'src/app/services/theme.service';
 import { AttachmentType, DocumentType, InformationType, MetadataType, PinnedType, SettingsType } from 'src/app/types';
 import {
   ActionItem,
@@ -49,6 +50,7 @@ import {
 export class App implements AfterViewInit {
 
   private readonly alertService:AlertService = inject(AlertService);
+  private readonly themeService:ThemeService = inject(ThemeService);
   private readonly httpService:HttpService = inject(HttpService);
   private readonly informationService:InformationService = inject(InformationService);
   private readonly dialog:MatDialog = inject(MatDialog);
@@ -555,6 +557,7 @@ export class App implements AfterViewInit {
     this.httpService.GET<SettingsType>('/settings').subscribe({
       next: (settings:SettingsType):void => {
         this.settings.set(settings);
+        this.themeService.applyColor(settings.color);
       },
       error: (error:HttpErrorResponse):void => {
         console.error(error.message || 'Unable to load settings');

--- a/frontend/src/app/components/settings/settings.component.html
+++ b/frontend/src/app/components/settings/settings.component.html
@@ -86,7 +86,11 @@
               <mat-option value="light">Light</mat-option>
             </mat-select>
           </mat-form-field>
-          <mat-form-field appearance="outline" class="full-width">
+          <mat-form-field
+            appearance="outline"
+            class="full-width color-field"
+            [style.--color-field-background]="form.controls.color.value"
+          >
             <mat-label>Color</mat-label>
             <input
               matInput
@@ -94,9 +98,25 @@
               name="color"
               type="text"
               formControlName="color"
-              readonly
             />
+            <button
+              mat-icon-button
+              matSuffix
+              type="button"
+              aria-label="Open color picker"
+              (click)="openColorPicker()"
+            >
+              <span class="material-symbols-outlined">palette</span>
+            </button>
           </mat-form-field>
+          <input
+            #colorPicker
+            class="native-color-picker"
+            type="color"
+            tabindex="-1"
+            [value]="colorPickerValue()"
+            (input)="onColorPickerChange($event)"
+          />
         </div>
         <div class="actions">
           <button mat-stroked-button type="button" (click)="reset()" [disabled]="saving()">Reset</button>

--- a/frontend/src/app/components/settings/settings.component.html
+++ b/frontend/src/app/components/settings/settings.component.html
@@ -89,6 +89,7 @@
           <mat-form-field
             appearance="outline"
             class="full-width color-field"
+            [class.color-field-invalid]="form.controls.color.invalid"
             [style.--color-field-background]="form.controls.color.value"
           >
             <mat-label>Color</mat-label>

--- a/frontend/src/app/components/settings/settings.component.scss
+++ b/frontend/src/app/components/settings/settings.component.scss
@@ -34,6 +34,20 @@
   }
 }
 
+.color-field-invalid {
+  --mat-form-field-outlined-input-text-color: #b3261e;
+  --mat-form-field-outlined-caret-color: #b3261e;
+
+  input {
+    color: #b3261e;
+    caret-color: #b3261e;
+  }
+
+  button {
+    color: #b3261e;
+  }
+}
+
 .native-color-picker {
   position: fixed;
   width: 1px;

--- a/frontend/src/app/components/settings/settings.component.scss
+++ b/frontend/src/app/components/settings/settings.component.scss
@@ -11,6 +11,37 @@
   width: 100%;
 }
 
+.color-field {
+  --mat-form-field-outlined-input-text-color: #ffffff;
+  --mat-form-field-outlined-caret-color: #ffffff;
+
+  ::ng-deep .mat-mdc-text-field-wrapper {
+    background-color: var(--color-field-background);
+  }
+
+  ::ng-deep .mat-mdc-floating-label {
+    padding: 0 4px;
+    background-color: #ffffff;
+  }
+
+  input {
+    color: #ffffff;
+    caret-color: #ffffff;
+  }
+
+  button {
+    color: #ffffff;
+  }
+}
+
+.native-color-picker {
+  position: fixed;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .actions {
   margin-top: 2rem;
   display: flex;

--- a/frontend/src/app/components/settings/settings.component.ts
+++ b/frontend/src/app/components/settings/settings.component.ts
@@ -1,7 +1,7 @@
 import { finalize, map } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { BreakpointObserver, BreakpointState } from '@angular/cdk/layout';
-import { Component, computed, inject, Signal, signal, WritableSignal } from '@angular/core';
+import { Component, computed, ElementRef, inject, Signal, signal, viewChild, WritableSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -11,6 +11,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { HttpService } from 'src/app/services/http.service';
 import { AlertService } from 'src/app/services/alert.service';
 import { InformationService } from 'src/app/services/information.service';
+import { ThemeService } from 'src/app/services/theme.service';
 import { SettingsType } from 'src/app/types';
 
 @Component({
@@ -27,6 +28,7 @@ export class SettingsComponent {
   private readonly alertService:AlertService = inject(AlertService);
   private readonly httpService:HttpService = inject(HttpService);
   private readonly informationService:InformationService = inject(InformationService);
+  private readonly themeService:ThemeService = inject(ThemeService);
   private readonly breakpointObserver:BreakpointObserver = inject(BreakpointObserver);
 
   private readonly formBuilder:FormBuilder = inject(FormBuilder);
@@ -35,6 +37,7 @@ export class SettingsComponent {
   protected readonly saving:WritableSignal<boolean> = signal(false);
   protected readonly isMobile:Signal<boolean> = toSignal(this.breakpointObserver.observe('(max-width: 992px)').pipe(map((state:BreakpointState):boolean => state.matches)), { initialValue: false });
   protected readonly isLocalMode:Signal<boolean> = computed(():boolean => this.informationService.retrieve()?.mode === 'local');
+  protected readonly colorPicker:Signal<ElementRef<HTMLInputElement>> = viewChild.required<ElementRef<HTMLInputElement>>('colorPicker');
 
   protected readonly form = this.formBuilder.nonNullable.group({
     title: [ '', [ Validators.required, Validators.maxLength(32) ] ],
@@ -85,6 +88,7 @@ export class SettingsComponent {
         next: ():void => {
           this.initialSettings = request;
           this.patchForm(request);
+          this.themeService.applyColor(request.color);
           this.alertService.success('Settings updated successfully.');
         },
         error: (error:HttpErrorResponse):void => {
@@ -121,6 +125,24 @@ export class SettingsComponent {
       template: settings.template,
       color: settings.color,
     });
+  }
+
+  protected colorPickerValue():string {
+    const color:string = this.form.controls.color.value;
+    if ( /^#[0-9A-Fa-f]{3}$/.test(color) ) {
+      return `#${ color[1] }${ color[1] }${ color[2] }${ color[2] }${ color[3] }${ color[3] }`;
+    }
+    return /^#[0-9A-Fa-f]{6}$/.test(color) ? color : '#000000';
+  }
+
+  protected openColorPicker():void {
+    this.colorPicker().nativeElement.click();
+  }
+
+  protected onColorPickerChange(event:Event):void {
+    const target:EventTarget | null = event.target;
+    if ( ! ( target instanceof HTMLInputElement ) ) { return; }
+    this.form.controls.color.setValue(target.value);
   }
 
 }

--- a/frontend/src/app/services/theme.service.ts
+++ b/frontend/src/app/services/theme.service.ts
@@ -1,0 +1,13 @@
+import { DOCUMENT } from '@angular/common';
+import { Injectable, inject } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+
+  private readonly document:Document = inject(DOCUMENT);
+
+  public applyColor(color:string):void {
+    this.document.documentElement.style.setProperty('--theme-color', color);
+  }
+
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -37,6 +37,7 @@ html {
 
 :root {
   --theme-color: #4caf50;
+  --mat-sys-primary: var(--theme-color);
   --app-font-family: Roboto, 'Helvetica Neue', Arial, sans-serif;
   --app-monospace-font-family: Consolas, 'Courier New', Courier, monospace;
 }


### PR DESCRIPTION
This pull request adds a user-friendly color picker to the settings page, allowing users to select a custom theme color, and ensures the selected color is applied consistently across the app. It introduces a new `ThemeService` to centralize theme color application, updates the UI and styles to support the color picker, and connects the color setting to the overall theme.

**Theme color customization:**
* Added a new `ThemeService` (`frontend/src/app/services/theme.service.ts`) to manage and apply the theme color across the app. The service updates the CSS variable `--theme-color` on the document root.
* Updated the main app initialization (`frontend/src/app/app.ts`) and settings update logic (`frontend/src/app/components/settings/settings.component.ts`) to apply the theme color using `ThemeService` whenever settings are loaded or changed. [[1]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R14) [[2]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R53) [[3]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R560) [[4]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000R14) [[5]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000R31) [[6]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000R91)

**Settings UI improvements:**
* Enhanced the color input field in the settings form to include a color picker button, improved validation feedback, and made the color field visually reflect the chosen color. [[1]](diffhunk://#diff-35c2bc6707a8ca30ff70815e8bbd8aedccf10fb42f234e250a93d5fcce0177a3L89-R120) [[2]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000L4-R4) [[3]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000R40) [[4]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000R130-R147)
* Updated styles for the color field and color picker to provide better visual feedback and accessibility.

**Theme variable integration:**
* Updated global styles to use the new `--theme-color` variable as the primary color for the app, ensuring consistent theming.

**Documentation:**
* Cleaned up the `README.md` to remove references to features under development that are not related to theming.