### PR TITLE
Clarify and improve document structure, rendering, and metadata logic

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -327,6 +327,8 @@ name, last name, and optionally password.
 
 A document node is a slug-normalized directory under `documents/`. Each directory may contain `content.md`, direct file
 attachments, child document directories, and `_versions`. A directory without `content.md` is an index-only node.
+It is returned with `exists: false` and its direct `children`; the frontend renders it as a hierarchy page. A path with
+neither content nor children remains a missing page.
 
 ```
 ┌─────────────────────────────────────────┐

--- a/backend/src/services/document.service.ts
+++ b/backend/src/services/document.service.ts
@@ -17,20 +17,21 @@ import {
 } from '@nestjs/common';
 import { PinnedService } from "src/services/pinned.service";
 import { EnvironmentService } from "src/services/environment.service";
-import { AttachmentSchema, ContentSchema, DocumentSchema, MetadataSchema, TokenSchema, TrashSchema, TreeSchema } from "src/schemas";
+import { SettingsService } from 'src/services/settings.service';
+import { AttachmentSchema, ContentSchema, DocumentSchema, MetadataSchema, SettingsSchema, TokenSchema, TrashSchema, TreeSchema } from 'src/schemas';
+
+interface FrontMatterInterface {
+  title: string;
+  timestamp: string;
+  author: string;
+  tags: string[];
+}
 
 export type AttachmentStream = {
   stream:ReadStream;
   fileType:string;
   fileName:string;
   contentLength:number;
-};
-
-interface FrontMatterInterface {
-  title:string;
-  timestamp:string;
-  author:string;
-  tags:string[];
 };
 
 @Injectable()
@@ -40,6 +41,7 @@ export class DocumentService {
 
   constructor(
     private readonly environmentService:EnvironmentService,
+    private readonly settingsService:SettingsService,
     @Inject(forwardRef(() => PinnedService))
     private readonly pinnedService:PinnedService
   ) {}
@@ -142,13 +144,8 @@ export class DocumentService {
   }
 
   public async buildDocumentMetadata(path:string, deleted:boolean = false):Promise<MetadataSchema> {
-    const document:MetadataSchema = {
-      path: '/' + this.environmentService.sanitizeDocumentPath(path),
-      title: '',
-      author: '',
-      timestamp: '',
-      tags: []
-    }
+    const sanitizedPath:string = this.environmentService.sanitizeDocumentPath(path);
+    const document:MetadataSchema = { path: '/' + sanitizedPath, title: '', author: '', timestamp: '', tags: [] }
     if ( await this.checkIfDocumentExists(path, deleted) ) {
       const parsedFrontMatter:FrontMatterInterface | null = await this.loadDocumentFrontMatter(path, deleted);
       if ( parsedFrontMatter ) {
@@ -158,7 +155,16 @@ export class DocumentService {
         document.tags = parsedFrontMatter.tags;
       }
     }
+    document.title = await this.resolveMetadataTitle(sanitizedPath, document.title);
     return document;
+  }
+
+  private async resolveMetadataTitle(sanitizedPath:string, title:string):Promise<string> {
+    const normalizedTitle:string = title.trim();
+    if ( normalizedTitle.length > 0 ) { return normalizedTitle; }
+    if ( sanitizedPath ) { return ( sanitizedPath.split('/').at(-1) ?? sanitizedPath ); }
+    const settings:SettingsSchema = await this.settingsService.retrieve();
+    return settings.title.trim();
   }
 
   private async loadDocumentFrontMatter(path:string, deleted:boolean = false):Promise<FrontMatterInterface | null> {

--- a/backend/src/services/document.service.ts
+++ b/backend/src/services/document.service.ts
@@ -290,15 +290,16 @@ export class DocumentService {
   }
 
   public async document_retrive(path:string):Promise<DocumentSchema> {
-    const exists:boolean = await this.checkIfDocumentExists(path);
+    const documentExists:boolean = await this.checkIfDocumentExists(path);
+    const directoryExists:boolean = await this.checkIfDirectoryExists(path);
     const pinned:boolean = await this.pinnedService.isPinned(path);
-    const metadata:MetadataSchema = await this.buildDocumentMetadata(path);
-    const children:MetadataSchema[] = ( exists ? await this.retriveChildren(path) : [] );
-    const attachments:AttachmentSchema[] = ( exists ? await this.retrieveAttachments(path) : [] );
-    const versions:string[] = ( exists ? await this.retrieveVersions(path) : [] );
-    const content:ContentSchema = ( exists ? await this.loadDocumentFullContent(path) : { raw: '' } );
-    this.logger.debug(`Document <${ path }> ${ exists ? 'retrieved' : 'not exists' }`);
-    return { exists, pinned, metadata, children, attachments, versions, content };
+    const metadata: MetadataSchema = await this.buildDocumentMetadata(path);
+    const children: MetadataSchema[] = directoryExists ? await this.retriveChildren(path) : [];
+    const attachments:AttachmentSchema[] = ( documentExists ? await this.retrieveAttachments(path) : [] );
+    const versions: string[] = documentExists ? await this.retrieveVersions(path) : [];
+    const content:ContentSchema = ( documentExists ? await this.loadDocumentFullContent(path) : { raw: '' } );
+    this.logger.debug(`Document <${ path }> ${ ( documentExists ? 'retrieved' : ( directoryExists ? 'traversed' : 'not exists' ) ) }`);
+    return { exists: documentExists, pinned, metadata, children, attachments, versions, content };
   }
 
   public async document_store(path:string, token:TokenSchema, content:ContentSchema):Promise<void> {

--- a/backend/test/e2e-documents.ts
+++ b/backend/test/e2e-documents.ts
@@ -66,6 +66,29 @@ describe('documents', ():void => {
     });
   });
 
+  it('represents a directory with child documents and no content as a hierarchy page', async ():Promise<void> => {
+    const documentsPath:string = join(testApp.datasetsPath, 'documents');
+    await mkdir(join(documentsPath, 'guides', 'hierarchy', 'child'), { recursive: true });
+    await writeFile(join(documentsPath, 'guides', 'hierarchy', 'child', 'content.md'), '# Child', 'utf-8');
+    await testApp.http
+      .get('/api/document')
+      .query({ path: '/guides/hierarchy' })
+      .set(bearer(adminToken))
+      .expect(200)
+      .expect(({ body }):void => {
+        expect(body).toMatchObject({
+          exists: false,
+          metadata: { path: '/guides/hierarchy', title: 'hierarchy' },
+          content: { raw: '' },
+          attachments: [],
+          versions: []
+        });
+        expect(body.children).toEqual(expect.arrayContaining([
+          expect.objectContaining({ path: '/guides/hierarchy/child', title: 'child' })
+        ]));
+      });
+  });
+
   it('uses fallback titles for documents without a title', async ():Promise<void> => {
     const documentsPath:string = join(testApp.datasetsPath, 'documents');
     await mkdir(join(documentsPath, 'guides', 'without-content'), { recursive: true });

--- a/backend/test/e2e-documents.ts
+++ b/backend/test/e2e-documents.ts
@@ -1,4 +1,6 @@
 import { authenticate, bearer, createE2eApp, E2e, initialize } from './e2e';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 describe('documents', ():void => {
 
@@ -62,6 +64,47 @@ describe('documents', ():void => {
       .expect(({ body }):void => {
       expect(body).toMatchObject({ exists: false, content: { raw: '' }, children: [], attachments: [], versions: [] });
     });
+  });
+
+  it('uses fallback titles for documents without a title', async ():Promise<void> => {
+    const documentsPath:string = join(testApp.datasetsPath, 'documents');
+    await mkdir(join(documentsPath, 'guides', 'without-content'), { recursive: true });
+    await mkdir(join(documentsPath, 'guides', 'blank-title'), { recursive: true });
+    await writeFile(
+      join(documentsPath, 'guides', 'blank-title', 'content.md'),
+      '---\ntitle: "   "\n---\nDocument body.\n',
+      'utf-8'
+    );
+    await writeFile(join(documentsPath, 'content.md'), 'Document body.\n', 'utf-8');
+    await testApp.http
+      .get('/api/document')
+      .query({ path: '/guides/without-content' })
+      .set(bearer(adminToken))
+      .expect(200)
+      .expect(({ body }):void => expect(body.metadata.title).toBe('without-content'));
+    await testApp.http
+      .get('/api/document')
+      .query({ path: '/guides/blank-title' })
+      .set(bearer(adminToken))
+      .expect(200)
+      .expect(({ body }):void => expect(body.metadata.title).toBe('blank-title'));
+    await testApp.http
+      .get('/api/document')
+      .query({ path: '/' })
+      .set(bearer(adminToken))
+      .expect(200)
+      .expect(({ body }):void => expect(body.metadata.title).toBe('E2E Wiki'));
+    await testApp.http
+      .get('/api/tree')
+      .query({ path: '/guides' })
+      .set(bearer(adminToken))
+      .expect(200)
+      .expect(({ body }):void => {
+        expect(body.leaves).toEqual(expect.arrayContaining([
+          expect.objectContaining({ path: '/guides/without-content', title: 'without-content' }),
+          expect.objectContaining({ path: '/guides/blank-title', title: 'blank-title' })
+        ]));
+      });
   });
 
   it('rejects invalid document move targets', async ():Promise<void> => {

--- a/frontend/src/app/components/document/document.component.html
+++ b/frontend/src/app/components/document/document.component.html
@@ -3,7 +3,11 @@
     @if (mode() === 'view') {
       @if (document(); as currentDocument) {
         @if (currentDocument.exists === false) {
-          <app-document-exists [canWrite]="canWrite()"/>
+          <app-document-exists
+            [canWrite]="canWrite()"
+            [hasChildren]="currentDocument.children.length > 0"
+            [metadata]="currentDocument.metadata"
+          />
         } @else {
           <app-document-viewer
             [metadata]="currentDocument.metadata"

--- a/frontend/src/app/components/document/exists/exists.component.html
+++ b/frontend/src/app/components/document/exists/exists.component.html
@@ -1,7 +1,14 @@
 <article>
-  <h1>Page not found</h1>
-  <p>This page does not exist yet.</p>
-  @if (canWrite()) {
-    <p>Would you like to create it now?</p>
+  @if (hasChildren()) {
+    <h1>{{ metadata().title }}</h1>
+    @if (canWrite()) {
+      <p>This page has no content yet.</p>
+    }
+  } @else {
+    <h1>Page not found</h1>
+    <p>This page does not exist yet.</p>
+    @if (canWrite()) {
+      <p>Would you like to create it now?</p>
+    }
   }
 </article>

--- a/frontend/src/app/components/document/exists/exists.component.ts
+++ b/frontend/src/app/components/document/exists/exists.component.ts
@@ -1,4 +1,5 @@
 import { Component, input, InputSignal } from '@angular/core';
+import { MetadataType } from 'src/app/types';
 
 @Component({
   standalone: true,
@@ -8,5 +9,7 @@ import { Component, input, InputSignal } from '@angular/core';
 export class DocumentExistsComponent {
 
   public readonly canWrite:InputSignal<boolean> = input<boolean>(false);
-  
+  public readonly hasChildren:InputSignal<boolean> = input<boolean>(false);
+  public readonly metadata:InputSignal<MetadataType> = input.required<MetadataType>();
+
 }

--- a/frontend/src/app/components/sidebar/sidebar.component.html
+++ b/frontend/src/app/components/sidebar/sidebar.component.html
@@ -25,10 +25,10 @@
           <a [routerLink]="entry.path" (click)="onNavLinkClick()">{{ entry.title }}</a>
         </li>
       }
-      @if (pinned()?.length && document()?.exists === true) {
+      @if (pinned()?.length && showDocument()) {
         <li class="nav-divider"></li>
       }
-      @if (document()?.exists === true) {
+      @if (showDocument()) {
         <li class="nav-section-label">Document</li>
         <li class="nav-item active">
           <strong>

--- a/frontend/src/app/components/sidebar/sidebar.component.ts
+++ b/frontend/src/app/components/sidebar/sidebar.component.ts
@@ -35,6 +35,11 @@ export class SidebarComponent {
     return ( notice.length > 0 ? notice : `Copyright ${ new Date().getFullYear() } All Rights Reserved` );
   });
 
+  protected readonly showDocument:Signal<boolean> = computed(():boolean => {
+    const document:DocumentType | null = this.document();
+    return !! document && ( document.exists === true || document.children.length > 0 );
+  });
+
   private normalizePath(url:string):string {
     const [ pathWithoutQuery ] = url.split('?');
     if ( ! pathWithoutQuery || pathWithoutQuery === '/' ) { return '/'; }


### PR DESCRIPTION
This pull request improves the handling and display of document directories without content, ensuring they are correctly represented as hierarchy pages rather than missing pages. It also introduces fallback logic for document titles and enhances the frontend to reflect these backend changes. Comprehensive tests are added to verify the new behaviors.

**Backend improvements:**

* Document directories without `content.md` but with children are now returned with `exists: false` and their direct `children`, allowing the frontend to render them as hierarchy pages instead of missing pages. [[1]](diffhunk://#diff-62e0de3653bb815662af0c1d681eac5e1edf338a05ff40d58609d6c64c76da07L287-R302) [[2]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR330-R331)
* Fallback logic for document titles: if a document or directory lacks a title, the service uses the directory name or a global default from settings. [[1]](diffhunk://#diff-62e0de3653bb815662af0c1d681eac5e1edf338a05ff40d58609d6c64c76da07L145-R148) [[2]](diffhunk://#diff-62e0de3653bb815662af0c1d681eac5e1edf338a05ff40d58609d6c64c76da07R158-R169)
* The `DocumentService` now injects `SettingsService` and uses it for retrieving default titles. [[1]](diffhunk://#diff-62e0de3653bb815662af0c1d681eac5e1edf338a05ff40d58609d6c64c76da07L20-R34) [[2]](diffhunk://#diff-62e0de3653bb815662af0c1d681eac5e1edf338a05ff40d58609d6c64c76da07R44)

**Frontend updates:**

* The document view and sidebar now properly display hierarchy pages (directories with children but no content) and show their titles. The `DocumentExistsComponent` receives `hasChildren` and `metadata` to adjust its rendering. [[1]](diffhunk://#diff-471816835a551bf96bf73ff7142923457aaa82f5ef0380346aced2a3a92e8ca4L6-R10) [[2]](diffhunk://#diff-1083e32ee23afe7e320094304ec9b6ed02365424ea4f097a4636e0631bb1d711R2-R13) [[3]](diffhunk://#diff-cc0b2a294ab8e0cf9155b317ebccec9adffd48106234c4295aa04e87144106a9R2) [[4]](diffhunk://#diff-cc0b2a294ab8e0cf9155b317ebccec9adffd48106234c4295aa04e87144106a9R12-R13) [[5]](diffhunk://#diff-6c3323f2c8a8315f34b11ffaabb8af4dd689adf8570b9b35797bce4d8eaf9faeL28-R31) [[6]](diffhunk://#diff-2e6bc7176983ab964b3788f29313685ba0e64039eac781ece0f0ab147e91d407R38-R42)

**Testing:**

* New end-to-end tests ensure directories with children but no content are rendered as hierarchy pages, and fallback title logic works as intended. [[1]](diffhunk://#diff-cffd9e6b8ea3830a0f4d3048bc48bc6bead804575669adf7f39de29a0de23c3bR2-R3) [[2]](diffhunk://#diff-cffd9e6b8ea3830a0f4d3048bc48bc6bead804575669adf7f39de29a0de23c3bR69-R132)