### PR TITLE
Fix #257: contain path traversal in attachment/image/version handling

### DIFF
--- a/classes/Document.class.php
+++ b/classes/Document.class.php
@@ -55,7 +55,8 @@ final class Document{
         $this->URL=URL.$this->ID;
         $this->DIR=ROOT.$this->PATH."/";
         $this->TITLE=self::getTitle($this->ID);
-        $this->VERSION=(strlen($_GET['version']??'')?$_GET['version']:"latest");
+        // sanitize version so it cannot traverse out of the versions directory
+        $this->VERSION=(strlen($_GET['version']??'')?wdf_safe_filename($_GET['version']):"latest");
         $this->FILE=$this->DIR."content.md";
         $this->TIMESTAMP=null;
         // check if file exist

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -87,10 +87,34 @@ function wdf_csrf_check():bool{
  * @return bool
  */
 function wdf_document_id_check(string $id):bool{
-  if (substr_count($id, "..") > 0 || substr_count($id, ':') > 0 || strpos($id, '/') === 0) {
+  // reject control characters, null bytes, backslashes and drive/scheme colons
+  if (preg_match('/[\x00-\x1F\x7F\\\\:]/', $id)) {
+    return false;
+  }
+  // reject parent traversal and absolute paths
+  if (substr_count($id, "..") > 0 || strpos($id, '/') === 0) {
     return false;
   }
   return true;
+}
+
+/**
+ * Safe File Name
+ *
+ * Reduce a user supplied file name to a single path component so it can never
+ * escape the document directory it is joined to.
+ *
+ * @param string $name File name
+ * @return string Sanitized file name (empty string if nothing usable remains)
+ */
+function wdf_safe_filename(string $name):string{
+  // normalize windows separators, then keep the last path component only
+  $name = basename(str_replace("\\", "/", $name));
+  // strip control characters and null bytes
+  $name = preg_replace('/[\x00-\x1F\x7F]/', '', $name);
+  // drop leading dots so "." and ".." cannot survive
+  $name = ltrim($name, ".");
+  return $name;
 }
 
 /**

--- a/submit.php
+++ b/submit.php
@@ -320,7 +320,7 @@ function image_upload_ajax(){
     return false;
   }
   // make file name
-  $file_name=strtolower(str_replace(" ","-",$image['name']));
+  $file_name=strtolower(str_replace(" ","-",wdf_safe_filename($image['name'])));
   // check for posted image
   if(isset($image['tmp_name']) && $image['tmp_name']){
     // sanitization for SVG
@@ -380,7 +380,7 @@ function image_drop_upload_ajax() {
     return false;
   }
   $image_base64 = $_POST['image_base64'];
-  $image_filename = $_POST['image_name'];
+  $image_filename = wdf_safe_filename($_POST['image_name']);
   if(Session::getInstance()->autenticationLevel()!=2){
     echo json_encode(array("error"=>1,"code"=>"not_authenticated"));
     return false;
@@ -466,7 +466,7 @@ function image_delete_ajax() {
     echo json_encode(array("error"=>1,"code"=>"csrf_error"));
     return false;
   }
-  $image_filename = basename($_POST['image_name']); // added basename()
+  $image_filename = wdf_safe_filename($_POST['image_name']);
   if(Session::getInstance()->autenticationLevel() != 2) {
     echo json_encode(array("error" => 1, "code" => "not_authenticated"));
     return false;
@@ -555,7 +555,7 @@ function attachment_upload_ajax(){
     return false;
   }
   // make file name
-  $file_name=strtolower(str_replace(" ","-",$attachment['name']));
+  $file_name=strtolower(str_replace(" ","-",wdf_safe_filename($attachment['name'])));
   // move temporary file
   $uploaded=move_uploaded_file($attachment['tmp_name'],$DOC->DIR.$file_name);
   // check for uploaded
@@ -583,7 +583,7 @@ function attachment_delete_ajax() {
     echo json_encode(array("error"=>1,"code"=>"csrf_error"));
     return false;
   }
-  $attachment_filename = $_POST['attachment_name'];
+  $attachment_filename = wdf_safe_filename($_POST['attachment_name']);
   if(Session::getInstance()->autenticationLevel() != 2) {
     echo json_encode(array("error" => 1, "code" => "not_authenticated"));
     return false;


### PR DESCRIPTION
## Summary

Fixes the path-traversal reported in #257 and hardens the sibling code paths that share the same root cause.

The `basename()` added to `image_delete_ajax()` in 98ea9ee only covered one of several places that join a user-supplied name to a document directory. The reporter's PoC still works verbatim against **`attachment_delete_ajax()`**, which passes `$_POST['attachment_name']` straight into `unlink($DOC->DIR.$name)`, so `attachment_name=../../<file>` deletes any file the web-server user can write.

The document **version** parameter has the same flaw: `Document::__construct()` reads `$_GET['version']` unvalidated and `content_restore()` feeds it to `copy($DOC->DIR."versions/".$VERSION.".md", …)`, so `?version=../../<other-doc>/content` copies another document's content into the current one.

## Fix

Adds one containment helper, `wdf_safe_filename()`, that normalizes separators, keeps only the last path component, strips control characters and drops leading dots, and applies it at every sink:

- `attachment_delete_ajax()` — the still-live #257 PoC
- `image_delete_ajax()` — replaces the partial `basename()` fix
- `image_drop_upload_ajax()`
- `attachment_upload_ajax()` / `image_upload_ajax()` — defense in depth (PHP already basenames `$_FILES['name']`, but the guard is made explicit)
- `Document::__construct()` — the version parameter

`wdf_document_id_check()` is also tightened to reject backslashes and control characters in addition to `..`, `:` and a leading `/`. Legitimate nested IDs like `samples/typography` are unaffected.

## Testing

Reproduced against `zavy86/wikidocs` in Docker, before and after the patch (authenticated as editor, real CSRF token):

| Vector | Before | After |
|---|---|---|
| `attachment_delete_ajax` `attachment_name=../../sentinel.txt` | file **deleted** outside doc dir | `attachment_not_found` (resolves to `exploit/sentinel.txt`) |
| `content_restore` `?version=../../other/content` | neighbour doc content copied in | blocked |

Regression (all pass): nested-id save, normal image/attachment upload + delete, real version restore round-trip.
