### PR TITLE
Fix #237: prevent open redirect in privacy agreement handling

### DIFF
--- a/classes/Session.class.php
+++ b/classes/Session.class.php
@@ -87,7 +87,7 @@ final class Session{
 			'httponly' => true,
 			'samesite' => 'Strict'
 		]);
-		header('Location:' . PATH . DOC);
+		header('Location: ' . wdf_safe_internal_path(DOC));
 	}
 
 	public function privacyAgreeded():bool{

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -35,6 +35,28 @@ function wdf_redirect(string $location):void{
 }
 
 /**
+ * Safe Internal Path
+ *
+ * Force a user supplied path to stay inside the application, blocking absolute,
+ * protocol relative and scheme prefixed targets so it cannot be used as an open
+ * redirect.
+ *
+ * @param string $path Requested path
+ * @return string Internal path prefixed with PATH
+ */
+function wdf_safe_internal_path(string $path):string{
+  // strip control characters (tab, CR, LF) that browsers remove from URLs and
+  // could otherwise hide a leading "//host"
+  $path=preg_replace('/[\x00-\x1F\x7F]/','',$path);
+  // normalize backslashes so "\evil.com" cannot be read as an authority
+  $path=str_replace("\\","/",$path);
+  // drop any scheme prefix (http:, javascript:, ...)
+  $path=preg_replace('#^[a-z][a-z0-9+.\-]*:#i','',$path);
+  // strip leading slashes so the result can never leave the current host
+  return PATH.ltrim($path,'/');
+}
+
+/**
  * Alert (if debug is enabled show a debug message)
  *
  * @param string $message Alert message


### PR DESCRIPTION
## Summary

Fixes the open redirect reported in #237.

`Session::privacyAgreement()` built its redirect as `PATH . DOC`, and `DOC` derives from `$_GET['doc']`. `htmlspecialchars()` in `bootstrap.inc.php` does not stop a protocol-relative target, so `?privacy=1&doc=//evil.com` sends the browser off-site. Backslash, scheme-prefixed and tab/newline variants bypass it the same way — browsers strip control characters from URLs and treat `\` as `/`.

## Fix

Adds `wdf_safe_internal_path()`, which strips control characters, normalizes backslashes, removes any scheme prefix, then strips leading slashes before prefixing `PATH` — so the destination can only be a path on the current host. `privacyAgreement()` now uses it.

## Testing

Reproduced in Docker; `Location` header resolved with a WHATWG URL parser against the site origin:

| `doc=` payload | Before → resolved origin | After |
|---|---|---|
| `//example.com` | `///example.com` → **example.com** | `/example.com` → same origin |
| `\example.com`, `/\example.com`, `\example.com` | → **example.com** | same origin |
| `https://example.com` | (on-site by luck) | `/example.com` |
| `%09//example.com` (leading TAB) | → **example.com** | same origin |

Legitimate document redirects (`homepage`, `samples/typography`, `some/nested-page`) still resolve to the correct on-site path.
