### PR TITLE
Fix #216: neutralize stored XSS via unclosed <iframe srcdoc>

### DIFF
--- a/classes/Document.class.php
+++ b/classes/Document.class.php
@@ -254,10 +254,16 @@ final class Document{
      */
     private static function sanitizeIframes($part) {
         $allowedHosts = self::allowedIframeHosts();
+        // The attribute chunk tokenizes quoted values so a value that itself
+        // contains ">" (e.g. srcdoc="<img ...>") does not truncate the match,
+        // and the closing </iframe> is optional so an UNCLOSED <iframe ...>
+        // is still caught and escaped. Without this an unclosed srcdoc iframe
+        // slipped through to Parsedown, which re-emitted it as a live element
+        // and re-decoded the srcdoc payload (stored XSS).
         return preg_replace_callback(
-            '#<iframe\b([^>]*?)(?:/\s*>|>\s*(.*?)</iframe\s*>)#is',
+            '#<iframe\b((?:"[^"]*"|\'[^\']*\'|[^>"\'])*)>(?:\s*(.*?)</iframe\s*>)?#is',
             function($m) use ($allowedHosts) {
-                $attrs = $m[1];
+                $attrs = rtrim($m[1], '/');
                 $inner = isset($m[2]) ? $m[2] : '';
                 // extract src
                 if (!preg_match('/\bsrc\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))/i', $attrs, $sm)) {


### PR DESCRIPTION
## Summary

Fixes the stored XSS reported in #216, which is **still reproducible** on current `master`.

`sanitizeIframes()` only matched iframes that had a closing `</iframe>` (or were self-closed). The reported payload has no closing tag:

```
<iframe srcdoc="<img src=x onerror=alert(1)>">
```

so it never matched and was left untouched by the allowlist/escape pass. The markdown renderer then treats the leftover opener as a raw HTML block, re-decodes its attribute value (reviving the `onerror` that `sanitizeHtml()` had already neutralized) and emits a **live** iframe. Because `srcdoc` is decoded again by the browser, the payload executes.

The served HTML for the stored doc is:

```html
<iframe srcdoc="&lt;img src=x onerror=alert(1)&gt;"></iframe>
```

which runs on load. (The *closed* form of the same payload is correctly neutralized already — this only affects the unclosed opener.)

## Fix

Match the opening `<iframe ...>` tag even when no `</iframe>` follows, and tokenize the attribute run so a quoted value containing `>` (like `srcdoc`) no longer truncates the match. Non-allowlisted iframes are then escaped to text as before; legitimate YouTube/Vimeo embeds are still rebuilt with safe attributes only (`srcdoc` and `on*` dropped).

## Testing

Verified in headless Chrome (CDP) against the running app. Payload's `onerror` sets `window.top.__XSS_FIRED`; table shows whether it fired:

| Payload | Before | After |
|---|---|---|
| `<iframe srcdoc="<img … onerror=…>">` (unclosed) | **fired** | not fired, no live iframe |
| single-quoted `srcdoc` / uppercase `<IFRAME>` / `<iframe/srcdoc=…>` | — | not fired |
| `<iframe src="javascript:…"></iframe>` | — | not fired, escaped |
| closed-tag variant | already inert | still inert |
| legit `https://www.youtube.com/embed/…` | rebuilt | rebuilt (safe attrs only) |

Fixes #216.
