### PR TITLE
Update app UI and infrastructure for version management and design

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,7 @@ for non-API, extensionless routes.
 | Variant | Runtime behavior                                                                                                 |
 |---------|------------------------------------------------------------------------------------------------------------------|
 | Watch   | Backend and frontend may run separately during development in watch mode.                                        |
-| Docker  | A single Node.js process serves the built Angular application at `/` and the Nest API at `/api`.                 |
+| Docker  | A single Node.js process listens on `3210`, serves the built frontend application at `/`, and the API at `/api`. |
 | Desktop | Electron starts the packaged backend as a child process and then loads the packaged frontend in its main window. |
 
 ## Runtime configuration
@@ -124,6 +124,7 @@ routes with an authorization additionally require at least one authorization dec
 | `PATCH`  | `/api/profile`      | JWT        | Update the current account profile.                       |
 | `GET`    | `/api/settings`     | Public     | Retrieve settings.                                        |
 | `PUT`    | `/api/settings`     | `manage`   | Overwrite settings.                                       |
+| `GET`    | `/api/release`      | `manage`   | Return installed and latest release.                      |
 | `GET`    | `/api/accounts`     | `manage`   | Retrieve accounts without password hashes.                |
 | `POST`   | `/api/accounts`     | `manage`   | Upsert accounts.                                          |
 | `DELETE` | `/api/accounts`     | `manage`   | Delete the account selected by `account`.                 |
@@ -187,6 +188,23 @@ only while uninitialized.
 
 Initialization creates default settings, one administrator account, an empty pinned list, the document and trash
 directories, and a root document. Password must be `null` in local mode and non-null in public or private mode.
+
+## Release checks
+
+The backend checks Pulse at startup and every eight hours, sending its package version and runtime `MODE` so Pulse can
+record active installations. Port `3000` uses the local Pulse service at `http://localhost:3001`; every other backend
+port uses `https://pulse.wikidocs.app`. Scheduled failures are logged and preserve the cached value. A forced
+`GET /api/release?force=true` check returns an error when Pulse is unavailable.
+
+```
+┌─────────────────────────────────────────┐
+│ ReleaseContract                         │
+├─────────────────────────────────────────┤
+│ Properties:                             │
+│ ├── current: string                     │
+│ └── latest: string                      │
+└─────────────────────────────────────────┘
+```
 
 ## Settings
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ The image is built from the `docker/dockerfile` and the compose stack is defined
 The docker image includes the backend and frontend, based on the `node:alpine` base image it runs the backend and the
 frontend is served as static files.
 
-The compose stack includes the image and a volume for the datasets, exposing the app on port 3000.
+The compose stack includes the image and a volume for the datasets, exposing the app on host port 3600.
 
 From repository root:
 
@@ -90,13 +90,13 @@ make docker-compose-up
 # Smoke checks
 docker compose -f docker/compose.yml -p wikidocs ps
 docker compose -f docker/compose.yml -p wikidocs logs --tail=100 wikidocs
-curl http://localhost:3000/api/information
+curl http://localhost:3600/api/information
 
 # Stop stack
 make docker-compose-down
 ```
 
-The compose stack exposes the app on `http://localhost:3000` and includes a container health check for the frontend `/`
+The compose stack exposes the app on `http://localhost:3600` and includes a container health check for the frontend `/`
 and for the backend `/api/health`.
 
 

--- a/README.md
+++ b/README.md
@@ -68,21 +68,21 @@ to run Wiki|Docs in a container.
 
 Running in container is the recommended way to self-host Wiki|Docs, as it is the easiest and fastest way to get started.
 
-You can access to the web client at `http://localhost:3000` after running the container, and you can also interact with
-the backend API at `http://localhost:3000/api/` where you can find the swagger documentation.
+You can access to the web client at `http://localhost:3210` after running the container, and you can also interact with
+the backend API at `http://localhost:3210/api/` where you can find the swagger documentation.
 
 
 #### Quick run
 
 ```
-docker run -p 3000:3000 zavy86/wikidocs:2
+docker run -p 3210:3210 zavy86/wikidocs:2
 ```
 
 
 #### Additional settings
 
 ```
-docker run --name wikidocs -d -p 3000:3000 -v /path/to/local/wikidocs/datasets/or/volume:/var/lib/wikidocs zavy86/wikidocs:2
+docker run --name wikidocs -d -p 3210:3210 -v /path/to/local/wikidocs/datasets/or/volume:/var/lib/wikidocs zavy86/wikidocs:2
 ```
 
 
@@ -103,7 +103,7 @@ services:
     volumes:
       - datasets:/var/lib/wikidocs/datasets
     ports:
-      - "3000:3000"
+      - "3210:3210"
 
 ```
 

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -1,6 +1,5 @@
 // @ts-check
 import eslint from '@eslint/js';
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -10,7 +9,6 @@ export default tseslint.config(
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
-  eslintPluginPrettierRecommended,
   {
     languageOptions: {
       globals: {
@@ -29,15 +27,6 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
       '@typescript-eslint/no-unsafe-argument': 'warn',
-      'prettier/prettier': ['error', { endOfLine: 'auto' }],
-      '@typescript-eslint/type-annotation-spacing': [
-        'error',
-        {
-          before: false,
-          after: false,
-          overrides: { arrow: { before: true, after: true } },
-        },
-      ],
       '@typescript-eslint/explicit-member-accessibility': [
         'warn',
         {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "archiver": "^8.0.0",
         "class-transformer": "^0.5.1",
@@ -2457,6 +2458,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.1.0.tgz",
@@ -2976,6 +2990,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.3.tgz",
+      "integrity": "sha512-pE7BSbKHiojpl4v7iEzdfFLXXJaH5RPJxI3Wr4x3HU59l83PJfhcUx4mGPWq245+DCAENAzRF/+ZoYr2tJCe/g==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5285,6 +5305,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8233,6 +8270,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "archiver": "^8.0.0",
     "class-transformer": "^0.5.1",

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,10 +1,10 @@
-import { Body, Controller, Delete, Get, Head, HttpCode, Patch, Post, Put, Query, Res, StreamableFile, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, DefaultValuePipe, Delete, Get, Head, HttpCode, ParseBoolPipe, Patch, Post, Put, Query, Res, StreamableFile, UploadedFile, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiBearerAuth, ApiBody, ApiConsumes, ApiOkResponse, ApiOperation, ApiProduces, ApiQuery, ApiTags } from "@nestjs/swagger";
 import type { Response } from 'express';
 import { Authorizations, JwtAccount, JwtToken, Public } from "src/app.decorators";
 import type { SyncStream } from "src/services";
-import { AccountsService, AttachmentStream, DocumentService, PinnedService, SearchService, SettingsService, SyncService, SystemService } from "src/services";
+import { AccountsService, AttachmentStream, DocumentService, PinnedService, ReleaseService, SearchService, SettingsService, SyncService, SystemService } from "src/services";
 import {
   AccountsSchema,
   ActionsSchema,
@@ -16,6 +16,7 @@ import {
   JwtSchema,
   PinnedSchema,
   ProfileSchema,
+  ReleaseSchema,
   SearchSchema,
   SettingsSchema,
   SnapshotSchema,
@@ -32,17 +33,18 @@ export class AppController {
     private readonly accountsService:AccountsService,
     private readonly documentService:DocumentService,
     private readonly pinnedService:PinnedService,
+    private readonly releaseService:ReleaseService,
     private readonly searchService:SearchService,
     private readonly systemService:SystemService,
     private readonly settingsService:SettingsService,
-    private readonly syncService:SyncService
+    private readonly syncService:SyncService,
   ) {}
 
   @Public()
   @Get('/health')
   @HttpCode(204)
   @ApiOperation({ summary: 'Check service availability' })
-  health():Promise<void> {
+  public health():Promise<void> {
     return this.systemService.health();
   }
 
@@ -50,15 +52,28 @@ export class AppController {
   @Get('/information')
   @HttpCode(200)
   @ApiOperation({ summary: 'Retrieve service information' })
-  information():Promise<InformationSchema> {
+  public information():Promise<InformationSchema> {
     return this.systemService.information();
+  }
+
+  @ApiBearerAuth()
+  @Authorizations('manage')
+  @Get('release')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Retrieve the installed and latest release versions' })
+  @ApiOkResponse({ type: ReleaseSchema })
+  @ApiQuery({ name: 'force', required: false, default: false })
+  public release_retrieve(
+    @Query('force') force:boolean,
+  ):Promise<ReleaseSchema> {
+    return this.releaseService.retrieve(force);
   }
 
   @Public()
   @Post('/initialize')
   @HttpCode(204)
   @ApiOperation({ summary: 'Initialize the datasets' })
-  initialize(
+  public initialize(
     @Body() request:InitializationSchema
   ):Promise<void> {
     return this.systemService.initialize(request);
@@ -68,7 +83,7 @@ export class AppController {
   @Head('token')
   @ApiOperation({ summary: 'Check given bearer token validity' })
   @HttpCode(204)
-  token(
+  public token(
     @JwtToken() token:TokenSchema,
   ):Promise<void> {
     return this.accountsService.verify(token);
@@ -78,7 +93,7 @@ export class AppController {
   @Get('guest')
   @ApiOperation({ summary: 'Try to get a guest session token' })
   @HttpCode(200)
-  guest():Promise<JwtSchema> {
+  public guest():Promise<JwtSchema> {
     return this.accountsService.guest();
   }
 
@@ -86,7 +101,7 @@ export class AppController {
   @Get('local')
   @ApiOperation({ summary: 'Try to get a local session token' })
   @HttpCode(200)
-  local():Promise<JwtSchema> {
+  public local():Promise<JwtSchema> {
     return this.accountsService.local();
   }
 
@@ -94,8 +109,8 @@ export class AppController {
   @Post('authenticate')
   @ApiOperation({ summary: 'Authenticate to get a session token' })
   @HttpCode(200)
-  authenticate(
-    @Body() request:AuthenticateSchema
+  public authenticate(
+    @Body() request:AuthenticateSchema,
   ):Promise<JwtSchema> {
     return this.accountsService.authenticate(request);
   }
@@ -104,9 +119,9 @@ export class AppController {
   @Patch('profile')
   @ApiOperation({ summary: 'Update your profile and password' })
   @HttpCode(204)
-  profile(
+  public profile(
     @JwtAccount() account:string,
-    @Body() request:ProfileSchema
+    @Body() request:ProfileSchema,
   ):Promise<void> {
     return this.accountsService.profile(account, request);
   }
@@ -115,7 +130,7 @@ export class AppController {
   @Get('settings')
   @ApiOperation({ summary: 'Retrieve system settings' })
   @HttpCode(200)
-  settings_retrieve():Promise<SettingsSchema> {
+  public settings_retrieve():Promise<SettingsSchema> {
     return this.settingsService.retrieve();
   }
 
@@ -124,8 +139,8 @@ export class AppController {
   @Put('settings')
   @ApiOperation({ summary: 'Store system settings' })
   @HttpCode(204)
-  settings_store(
-    @Body() request:SettingsSchema
+  public settings_store(
+    @Body() request:SettingsSchema,
   ):Promise<void> {
     return this.settingsService.store(request);
   }
@@ -135,7 +150,7 @@ export class AppController {
   @Get('/accounts')
   @HttpCode(200)
   @ApiOperation({ summary: 'Retrieve authorized accounts' })
-  accounts_retrieve():Promise<AccountsSchema> {
+  public accounts_retrieve():Promise<AccountsSchema> {
     return this.accountsService.retrieve();
   }
 
@@ -144,8 +159,8 @@ export class AppController {
   @Post('/accounts')
   @HttpCode(204)
   @ApiOperation({ summary: 'Store authorized accounts' })
-  accounts_store(
-    @Body() request:AccountsSchema
+  public accounts_store(
+    @Body() request:AccountsSchema,
   ):Promise<void> {
     return this.accountsService.store(request);
   }
@@ -156,8 +171,8 @@ export class AppController {
   @HttpCode(204)
   @ApiOperation({ summary: 'Delete authorized account' })
   @ApiQuery({ name: 'account', required: true })
-  accounts_remove(
-    @Query('account') account:string
+  public accounts_remove(
+    @Query('account') account:string,
   ):Promise<void> {
     return this.accountsService.remove(account);
   }
@@ -167,7 +182,7 @@ export class AppController {
   @Get('/pinned')
   @HttpCode(200)
   @ApiOperation({ summary: 'Retrieve documents pinned' })
-  pinned_retrieve():Promise<PinnedSchema> {
+  public pinned_retrieve():Promise<PinnedSchema> {
     return this.pinnedService.retrieve();
   }
 
@@ -177,8 +192,8 @@ export class AppController {
   @HttpCode(204)
   @ApiOperation({ summary: 'Pin a document' })
   @ApiQuery({ name: 'path', required: true })
-  pinned_store(
-    @Query('path') path:string
+  public pinned_store(
+    @Query('path') path:string,
   ):Promise<void> {
     return this.pinnedService.store(path);
   }
@@ -190,9 +205,9 @@ export class AppController {
   @ApiOperation({ summary: 'Sort a pinned document' })
   @ApiQuery({ name: 'path', required: true })
   @ApiQuery({ name: 'sorting', required: true })
-  pinned_sort(
+  public pinned_sort(
     @Query('path') path:string,
-    @Query('sorting') sorting:number
+    @Query('sorting') sorting:number,
   ):Promise<void> {
     return this.pinnedService.sort(path, sorting);
   }
@@ -203,8 +218,8 @@ export class AppController {
   @HttpCode(204)
   @ApiOperation({ summary: 'Unpin a document' })
   @ApiQuery({ name: 'path', required: true })
-  pinned_remove(
-    @Query('path') path:string
+  public pinned_remove(
+    @Query('path') path:string,
   ):Promise<void> {
     return this.pinnedService.remove(path);
   }
@@ -215,8 +230,8 @@ export class AppController {
   @HttpCode(200)
   @ApiOperation({ summary: 'Search for documents' })
   @ApiQuery({ name: 'query', required: true })
-  search(
-    @Query('query') query:string
+  public search(
+    @Query('query') query:string,
   ):Promise<SearchSchema> {
     return this.searchService.search(query);
   }
@@ -227,8 +242,8 @@ export class AppController {
   @HttpCode(200)
   @ApiOperation({ summary: 'Retrieve direct children of a tree path' })
   @ApiQuery({ name: 'path', required: true })
-  tree(
-    @Query('path') path:string
+  public tree(
+    @Query('path') path:string,
   ):Promise<TreeSchema> {
     return this.documentService.tree(path);
   }
@@ -239,8 +254,8 @@ export class AppController {
   @HttpCode(200)
   @ApiOperation({ summary: 'Retrieve a document' })
   @ApiQuery({ name: 'path', required: true })
-  document_retrieve(
-    @Query('path') path:string
+  public document_retrieve(
+    @Query('path') path:string,
   ):Promise<DocumentSchema> {
     return this.documentService.document_retrive(path);
   }
@@ -251,10 +266,10 @@ export class AppController {
   @HttpCode(204)
   @ApiOperation({ summary: 'Store a document' })
   @ApiQuery({ name: 'path', required: true })
-  document_store(
+  public document_store(
     @Query('path') path:string,
     @JwtToken() token:TokenSchema,
-    @Body() content:ContentSchema
+    @Body() content:ContentSchema,
   ):Promise<void> {
     return this.documentService.document_store(path, token, content);
   }
@@ -266,9 +281,9 @@ export class AppController {
   @ApiOperation({ summary: 'Move a document' })
   @ApiQuery({ name: 'path', required: true })
   @ApiQuery({ name: 'destination', required: true })
-  document_move(
+  public document_move(
     @Query('path') path:string,
-    @Query('destination') destination:string
+    @Query('destination') destination:string,
   ):Promise<void> {
     return this.documentService.document_move(path, destination);
   }
@@ -280,7 +295,7 @@ export class AppController {
   @ApiOperation({ summary: 'Remove a document' })
   @ApiQuery({ name: 'path', required: true })
   @Authorizations('delete')
-  document_remove(
+  public document_remove(
     @Query('path') path:string,
   ):Promise<void> {
     return this.documentService.document_remove(path);
@@ -293,9 +308,9 @@ export class AppController {
   @ApiOperation({ summary: 'Retrieve a document version' })
   @ApiQuery({ name: 'path', required: true })
   @ApiQuery({ name: 'timestamp', required: true })
-  version_retrieve(
+  public version_retrieve(
     @Query('path') path:string,
-    @Query('timestamp') timestamp:string
+    @Query('timestamp') timestamp:string,
   ):Promise<ContentSchema> {
     return this.documentService.version_retrieve(path, timestamp);
   }
@@ -307,9 +322,9 @@ export class AppController {
   @ApiOperation({ summary: 'Remove a document version' })
   @ApiQuery({ name: 'path', required: true })
   @ApiQuery({ name: 'timestamp', required: true })
-  version_remove(
+  public version_remove(
     @Query('path') path:string,
-    @Query('timestamp') timestamp:string
+    @Query('timestamp') timestamp:string,
   ):Promise<void> {
     return this.documentService.version_remove(path, timestamp);
   }
@@ -323,11 +338,11 @@ export class AppController {
   @ApiQuery({ name: 'token', required: true })
   @ApiProduces('application/octet-stream')
   @ApiOkResponse({ content: { 'application/octet-stream': { schema: { type: 'string', format: 'binary' } } } })
-  async attachment_retrieve(
+  public async attachment_retrieve(
     @Query('path') path:string,
     @Query('file') file:string,
     @Query('token') token:string,
-    @Res({ passthrough: true }) response:Response
+    @Res({ passthrough: true }) response:Response,
   ):Promise<StreamableFile> {
     const attachment:AttachmentStream = await this.documentService.attachment_retrive(path, file, token);
     const escapedFileName:string = attachment.fileName.replace(/"/g, '\\"');
@@ -346,11 +361,11 @@ export class AppController {
   @ApiQuery({ name: 'file', required: true })
   @ApiConsumes('multipart/form-data')
   @UseInterceptors(FileInterceptor('file'))
-  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: [ 'file' ] } })
-  attachment_store(
+  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: ['file'] } })
+  public attachment_store(
     @Query('path') path:string,
     @Query('file') file:string,
-    @UploadedFile() uploaded:{ buffer:Buffer }
+    @UploadedFile() uploaded:{ buffer:Buffer },
   ):Promise<void> {
     return this.documentService.attachment_store(path, file, uploaded);
   }
@@ -362,9 +377,9 @@ export class AppController {
   @ApiOperation({ summary: 'Remove an attachment' })
   @ApiQuery({ name: 'path', required: true })
   @ApiQuery({ name: 'file', required: true })
-  attachment_remove(
+  public attachment_remove(
     @Query('path') path:string,
-    @Query('file') file:string
+    @Query('file') file:string,
   ):Promise<void> {
     return this.documentService.attachment_remove(path, file);
   }
@@ -374,7 +389,7 @@ export class AppController {
   @Get('trash')
   @HttpCode(200)
   @ApiOperation({ summary: 'Retrieve deleted documents' })
-  trash_retrieve():Promise<TrashSchema> {
+  public trash_retrieve():Promise<TrashSchema> {
     return this.documentService.trash_retrieve();
   }
 
@@ -385,9 +400,9 @@ export class AppController {
   @ApiOperation({ summary: 'Restore a deleted document' })
   @ApiQuery({ name: 'path', required: true })
   @ApiQuery({ name: 'destination', required: true })
-  trash_recover(
+  public trash_recover(
     @Query('path') path:string,
-    @Query('destination') destination:string
+    @Query('destination') destination:string,
   ):Promise<void> {
     return this.documentService.trash_recover(path, destination);
   }
@@ -398,8 +413,8 @@ export class AppController {
   @HttpCode(204)
   @ApiOperation({ summary: 'Permanently remove a deleted document' })
   @ApiQuery({ name: 'path', required: true })
-  trash_remove(
-    @Query('path') path:string
+  public trash_remove(
+    @Query('path') path:string,
   ):Promise<void> {
     return this.documentService.trash_remove(path);
   }
@@ -409,7 +424,7 @@ export class AppController {
   @Get('sync')
   @HttpCode(200)
   @ApiOperation({ summary: 'Retrieve current document snapshot' })
-  sync_snapshot():Promise<SnapshotSchema> {
+  public sync_snapshot():Promise<SnapshotSchema> {
     return this.syncService.sync_snapshot();
   }
 
@@ -420,9 +435,9 @@ export class AppController {
   @ApiOperation({ summary: 'Send actions and retrieve changes' })
   @ApiProduces('application/zip')
   @ApiOkResponse({ content: { 'application/zip': { schema: { type: 'string', format: 'binary' } } } })
-  async sync_actions(
+  public async sync_actions(
     @Body() actions:ActionsSchema,
-    @Res({ passthrough: true }) response:Response
+    @Res({ passthrough: true }) response:Response,
   ):Promise<StreamableFile> {
     const archive:SyncStream = await this.syncService.sync_actions(actions);
     response.type('application/zip');
@@ -440,11 +455,10 @@ export class AppController {
   @ApiOperation({ summary: 'Apply uploaded sync archive' })
   @ApiConsumes('multipart/form-data')
   @UseInterceptors(FileInterceptor('file'))
-  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: [ 'file' ] } })
-  sync_import(
-    @UploadedFile() uploaded:{ buffer:Buffer }
+  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } }, required: ['file'] } })
+  public sync_import(
+    @UploadedFile() uploaded:{ buffer:Buffer },
   ):Promise<void> {
     return this.syncService.sync_import(uploaded);
   }
-
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,13 +2,15 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_GUARD } from "@nestjs/core";
 import { JwtModule } from "@nestjs/jwt";
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from "src/app.controller";
 import { AppGuard } from "src/app.guard";
-import { AccountsService, DocumentService, EnvironmentService, PinnedService, SearchService, SettingsService, SystemService, SyncService } from "src/services";
+import { AccountsService, DocumentService, EnvironmentService, PinnedService, ReleaseService, SearchService, SettingsService, SystemService, SyncService } from "src/services";
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    ScheduleModule.forRoot(),
     JwtModule
   ],
   controllers: [
@@ -19,6 +21,7 @@ import { AccountsService, DocumentService, EnvironmentService, PinnedService, Se
     DocumentService,
     EnvironmentService,
     PinnedService,
+    ReleaseService,
     SearchService,
     SettingsService,
     SystemService,

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -12,6 +12,7 @@ export * from 'src/schemas/metadata.schema';
 export * from 'src/schemas/pin.schema';
 export * from 'src/schemas/pinned.schema';
 export * from 'src/schemas/profile.schema';
+export * from 'src/schemas/release.schema';
 export * from 'src/schemas/search.schema';
 export * from 'src/schemas/settings.schema';
 export * from 'src/schemas/snapshot.schema';

--- a/backend/src/schemas/release.schema.ts
+++ b/backend/src/schemas/release.schema.ts
@@ -1,0 +1,15 @@
+import { Expose } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import type { ReleaseContract } from '@shared/contracts';
+
+export class ReleaseSchema implements ReleaseContract {
+
+  @Expose()
+  @ApiProperty({ example: '1.2.3' })
+  current:string;
+
+  @Expose()
+  @ApiProperty({ example: '2.3.4' })
+  latest:string;
+
+}

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -2,6 +2,7 @@ export * from 'src/services/accounts.service';
 export * from 'src/services/document.service';
 export * from 'src/services/environment.service';
 export * from 'src/services/pinned.service';
+export * from 'src/services/release.service';
 export * from 'src/services/search.service';
 export * from 'src/services/settings.service';
 export * from 'src/services/system.service';

--- a/backend/src/services/release.service.ts
+++ b/backend/src/services/release.service.ts
@@ -1,0 +1,87 @@
+import { version } from '../../package.json';
+import { Injectable, Logger, OnModuleInit, ServiceUnavailableException } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import { EnvironmentService } from 'src/services/environment.service';
+import { ReleaseSchema } from 'src/schemas';
+
+const DEVELOPMENT_BACKEND_PORT:string = '3000';
+const DEVELOPMENT_PULSE_URL:string = 'http://localhost:3001';
+const PRODUCTION_PULSE_URL:string = 'https://pulse.wikidocs.app';
+const RELEASE_INTERVAL:number = ( 8 * 60 * 60 * 1000 );
+
+@Injectable()
+export class ReleaseService implements OnModuleInit {
+  private readonly logger:Logger = new Logger(ReleaseService.name);
+
+  private latest:string = version;
+
+  private refreshRequest:Promise<void> | null = null;
+
+  constructor(private readonly environmentService:EnvironmentService) {}
+
+  public onModuleInit():void {
+    void this.refreshScheduled();
+  }
+
+  private refresh():Promise<void> {
+    if (this.refreshRequest) {
+      return this.refreshRequest;
+    }
+    this.refreshRequest = this.requestLatestRelease().finally(():void => {
+      this.refreshRequest = null;
+    });
+    return this.refreshRequest;
+  }
+
+  private async requestLatestRelease():Promise<void> {
+    const url:URL = new URL('/api/latest', this.getPulseUrl());
+    url.searchParams.set('mode', this.environmentService.getMode());
+    url.searchParams.set('version', version);
+    const response:Response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Pulse returned HTTP ${response.status}`);
+    }
+    const payload:unknown = await response.json();
+    if ( typeof payload !== 'object' || payload === null || typeof ( payload as { version?:unknown } ).version !== 'string' ) {
+      throw new Error('Pulse returned an invalid latest release payload');
+    }
+    const latest:string = ( payload as { version:string } ).version.trim();
+    if (!latest) {
+      throw new Error('Pulse returned an empty latest release version');
+    }
+    if (latest !== this.latest) {
+      this.latest = latest;
+      this.logger.log(`Latest release updated from Pulse to <${ latest }>`);
+    }
+  }
+
+  private getPulseUrl():string {
+    return ( ( process.env.PORT ?? DEVELOPMENT_BACKEND_PORT ) === DEVELOPMENT_BACKEND_PORT ? DEVELOPMENT_PULSE_URL : PRODUCTION_PULSE_URL );
+  }
+
+  public async retrieve(force:boolean = false):Promise<ReleaseSchema> {
+    if (force) {
+      try {
+        await this.refresh();
+      } catch (error:unknown) {
+        const message:string = ( error instanceof Error ? error.message : String(error) );
+        throw new ServiceUnavailableException(`Unable to check for new versions: ${ message }`);
+      }
+    }
+    return {
+      current: version,
+      latest: this.latest
+    };
+  }
+
+  @Interval(RELEASE_INTERVAL)
+  public async refreshScheduled():Promise<void> {
+    try {
+      await this.refresh();
+    } catch (error:unknown) {
+      const message:string = ( error instanceof Error ? error.message : String(error) );
+      this.logger.error(`Unable to refresh latest release: ${ message }`);
+    }
+  }
+
+}

--- a/desktop/.eslintrc.json
+++ b/desktop/.eslintrc.json
@@ -61,6 +61,19 @@
     "array-bracket-spacing": [
       "error",
       "never"
+    ],
+    "@typescript-eslint/type-annotation-spacing": [
+      "error",
+      {
+        "before": false,
+        "after": false,
+        "overrides": {
+          "arrow": {
+            "before": true,
+            "after": true
+          }
+        }
+      }
     ]
   }
 }

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -10,11 +10,11 @@ services:
       MODE: public
       SECRET: ${SECRET:-wikidocs-insecure-secret-to-be-changed}
     ports:
-      - "3600:3000"
+      - "3600:3210"
     volumes:
       - datasets:/var/lib/wikidocs/datasets
     healthcheck:
-      test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null && wget -qO- http://127.0.0.1:3000/api/health >/dev/null || exit 1" ]
+      test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:3210/ >/dev/null && wget -qO- http://127.0.0.1:3210/api/health >/dev/null || exit 1" ]
       retries: 6
       timeout: 9s
       interval: 60s

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -24,7 +24,7 @@ RUN npm prune --omit=dev
 FROM node:22-alpine AS runtime
 ENV NODE_ENV=production
 ENV MODE=public
-ENV PORT=3000
+ENV PORT=3210
 ENV FRONTEND=/app/frontend
 ENV SECRET=wikidocs-insecure-secret-to-be-changed
 ENV DATASETS=/var/lib/wikidocs/datasets
@@ -36,6 +36,6 @@ WORKDIR /app/backend
 COPY --from=backend-build /app/backend/node_modules ./node_modules
 COPY --from=backend-build /app/backend/dist ./dist
 COPY --from=frontend-build /app/frontend/dist/wikidocs-frontend/browser/ /app/frontend/
-EXPOSE 3000
+EXPOSE 3210
 USER node
 CMD ["node", "/app/backend/dist/backend/src/main.js"]

--- a/frontend/src/app/app.scss
+++ b/frontend/src/app/app.scss
@@ -43,6 +43,7 @@
   .app-drawer {
     border-right: 0;
   }
+
 }
 
 @media print {

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -6,13 +6,14 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
-import { SessionService } from 'src/app/services/session.service';
+import { AuthenticationChange, SessionService } from 'src/app/services/session.service';
 import { HttpService } from 'src/app/services/http.service';
 import { InformationService } from 'src/app/services/information.service';
 import { PrivacyService } from 'src/app/services/privacy.service';
 import { AlertService } from 'src/app/services/alert.service';
 import { ThemeService } from 'src/app/services/theme.service';
 import { SettingsService } from 'src/app/services/settings.service';
+import { ReleaseService } from 'src/app/services/release.service';
 import { AttachmentType, DocumentType, InformationType, MetadataType, PinnedType, SettingsType } from 'src/app/types';
 import {
   ActionItem,
@@ -31,6 +32,8 @@ import {
   PrivacyComponent,
   PromptComponent,
   PromptData,
+  ReleaseComponent,
+  ReleaseDialogData,
   SidebarComponent,
   StartupComponent,
   TopComponent,
@@ -54,6 +57,7 @@ export class App implements AfterViewInit {
   private readonly themeService:ThemeService = inject(ThemeService);
   private readonly httpService:HttpService = inject(HttpService);
   private readonly settingsService:SettingsService = inject(SettingsService);
+  private readonly releaseService:ReleaseService = inject(ReleaseService);
   private readonly informationService:InformationService = inject(InformationService);
   private readonly dialog:MatDialog = inject(MatDialog);
   private readonly privacyService:PrivacyService = inject(PrivacyService);
@@ -69,6 +73,8 @@ export class App implements AfterViewInit {
   private readonly privacyComponent:Signal<PrivacyComponent> = viewChild.required(PrivacyComponent);
 
   private privacyModalPrompted:boolean = false;
+
+  private releaseDialogOpen:boolean = false;
 
   protected readonly startupError:Signal<string | null> = computed(():string | null => {
     return this.informationService.error() ?? this.sessionService.startupError();
@@ -269,16 +275,18 @@ export class App implements AfterViewInit {
 
   constructor() {
     effect(():void => this.openPrivacyModalIfNeeded());
+    effect(():void => this.openReleaseDialogIfNeeded());
     this.loadInformationBoundState();
     this.loadDocumentForCurrentUrl();
     this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(():void => {
       this.loadInformationBoundState();
       this.loadDocumentForCurrentUrl();
     });
-    this.sessionService.authenticationChangedEvent.subscribe(():void => {
+    this.sessionService.authenticationChangedEvent.subscribe((change:AuthenticationChange):void => {
       if ( ! this.informationService.isInitialized() ) { return; }
       this.updateAuthenticationState();
       this.loadPinnedIfSessionReady();
+      if ( change === 'login' ) { this.loadReleaseIfAuthorized(); }
     });
   }
 
@@ -380,6 +388,21 @@ export class App implements AfterViewInit {
     queueMicrotask(():void => this.privacyComponent().open());
   }
 
+  private openReleaseDialogIfNeeded():void {
+    if ( ! this.hasManageAuthorization() || ! this.releaseService.shouldShowDialog() || this.releaseDialogOpen ) { return; }
+    const release = this.releaseService.release();
+    if ( ! release ) { return; }
+    this.releaseDialogOpen = true;
+    const data:ReleaseDialogData = { latest: release.latest };
+    this.dialog
+      .open(ReleaseComponent, { width: '90vw', maxWidth: '480px', data })
+      .afterClosed()
+      .subscribe(():void => {
+        this.releaseDialogOpen = false;
+        this.releaseService.dismiss();
+      });
+  }
+
   private updateAuthenticationState():void {
     const isValid:boolean = this.sessionService.isValid();
     const isGuestUser:boolean = this.sessionService.isGuestUser();
@@ -391,6 +414,11 @@ export class App implements AfterViewInit {
     this.hasWriteAuthorization.set(isValid && this.sessionService.hasAuthorization('write'));
     this.hasDeleteAuthorization.set(isValid && this.sessionService.hasAuthorization('delete'));
     this.hasManageAuthorization.set(isValid && this.sessionService.hasAuthorization('manage'));
+  }
+
+  private loadReleaseIfAuthorized():void {
+    if ( ! this.hasManageAuthorization() ) { return; }
+    this.releaseService.refresh().subscribe({ error: ():void => undefined });
   }
 
   private logout():void {

--- a/frontend/src/app/components/confirm/confirm.component.html
+++ b/frontend/src/app/components/confirm/confirm.component.html
@@ -1,6 +1,6 @@
 <h2 mat-dialog-title class="app-dialog-title">{{ data.title }}</h2>
 <mat-dialog-content>
-  <p class="dialog-message">{{ data.message }}</p>
+  <p class="app-dialog-message">{{ data.message }}</p>
 </mat-dialog-content>
 <mat-dialog-actions align="end">
   <button mat-stroked-button type="button" (click)="cancel()">{{ data.cancelLabel }}</button>

--- a/frontend/src/app/components/confirm/confirm.component.scss
+++ b/frontend/src/app/components/confirm/confirm.component.scss
@@ -1,4 +1,0 @@
-.dialog-message {
-  margin: 0;
-  white-space: pre-line;
-}

--- a/frontend/src/app/components/confirm/confirm.component.ts
+++ b/frontend/src/app/components/confirm/confirm.component.ts
@@ -14,7 +14,6 @@ export type ConfirmData = {
   standalone: true,
   selector: 'app-confirm',
   templateUrl: './confirm.component.html',
-  styleUrl: './confirm.component.scss',
   imports: [ MatDialogModule, MatButtonModule ],
 })
 export class ConfirmComponent {

--- a/frontend/src/app/components/index.ts
+++ b/frontend/src/app/components/index.ts
@@ -15,6 +15,7 @@ export * from 'src/app/components/header/header.component';
 export * from 'src/app/components/initialization/initialization.component';
 export * from 'src/app/components/privacy/privacy.component';
 export * from 'src/app/components/profile/profile.component';
+export * from 'src/app/components/release/release.component';
 export * from 'src/app/components/search/search.component';
 export * from 'src/app/components/settings/settings.component';
 export * from 'src/app/components/sidebar/sidebar.component';

--- a/frontend/src/app/components/prompt/prompt.component.html
+++ b/frontend/src/app/components/prompt/prompt.component.html
@@ -1,6 +1,6 @@
 <h2 mat-dialog-title class="app-dialog-title">{{ data.title }}</h2>
 <mat-dialog-content>
-  <p class="dialog-message">{{ data.message }}</p>
+  <p class="app-dialog-message">{{ data.message }}</p>
   <form [formGroup]="form" (ngSubmit)="submit()">
     <mat-form-field appearance="outline" class="app-form-control-full-width">
       <mat-label>{{ data.label }}</mat-label>

--- a/frontend/src/app/components/prompt/prompt.component.scss
+++ b/frontend/src/app/components/prompt/prompt.component.scss
@@ -1,4 +1,0 @@
-.dialog-message {
-  margin: 0 0 0.75rem;
-  white-space: pre-line;
-}

--- a/frontend/src/app/components/prompt/prompt.component.ts
+++ b/frontend/src/app/components/prompt/prompt.component.ts
@@ -18,7 +18,6 @@ export type PromptData = {
   standalone: true,
   selector: 'app-prompt',
   templateUrl: './prompt.component.html',
-  styleUrl: './prompt.component.scss',
   imports: [ ReactiveFormsModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatInputModule ],
 })
 export class PromptComponent {

--- a/frontend/src/app/components/release/release.component.html
+++ b/frontend/src/app/components/release/release.component.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title class="app-dialog-title">New version available</h2>
+<mat-dialog-content>
+  <p class="app-dialog-message">Version {{ data.latest }} is available.</p>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-stroked-button type="button" (click)="close()">Dismiss</button>
+  <a mat-flat-button color="primary" href="https://github.com/Zavy86/WikiDocs/releases" target="_blank" rel="noopener" (click)="close()">View releases</a>
+</mat-dialog-actions>

--- a/frontend/src/app/components/release/release.component.ts
+++ b/frontend/src/app/components/release/release.component.ts
@@ -1,0 +1,25 @@
+import { Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+
+export type ReleaseDialogData = {
+  readonly latest:string;
+};
+
+@Component({
+  standalone: true,
+  selector: 'app-release',
+  templateUrl: './release.component.html',
+  imports: [ MatButtonModule, MatDialogModule ],
+})
+export class ReleaseComponent {
+
+  private readonly dialogRef:MatDialogRef<ReleaseComponent> = inject(MatDialogRef<ReleaseComponent>);
+
+  protected readonly data:ReleaseDialogData = inject<ReleaseDialogData>(MAT_DIALOG_DATA);
+
+  protected close():void {
+    this.dialogRef.close();
+  }
+
+}

--- a/frontend/src/app/components/settings/settings.component.html
+++ b/frontend/src/app/components/settings/settings.component.html
@@ -82,6 +82,7 @@
         </div>
         <div class="app-form-actions">
           <button mat-stroked-button type="button" (click)="reset()" [disabled]="saving()">Reset</button>
+          <button mat-stroked-button type="button" (click)="checkForNewVersions()" [disabled]="checkingRelease()">{{ checkingRelease() ? 'Checking...' : 'Check for new versions' }}</button>
           <button mat-flat-button color="primary" type="submit" [disabled]="saving() || timezoneLoadError() !== null">{{ saving() ? 'Saving...' : 'Save' }}</button>
         </div>
       </form>

--- a/frontend/src/app/components/settings/settings.component.ts
+++ b/frontend/src/app/components/settings/settings.component.ts
@@ -14,6 +14,7 @@ import { AlertService } from 'src/app/services/alert.service';
 import { InformationService } from 'src/app/services/information.service';
 import { ThemeService } from 'src/app/services/theme.service';
 import { SettingsType } from 'src/app/types';
+import { ReleaseService } from 'src/app/services/release.service';
 
 @Component({
   standalone: true,
@@ -29,6 +30,7 @@ export class SettingsComponent {
   private readonly alertService:AlertService = inject(AlertService);
   private readonly httpService:HttpService = inject(HttpService);
   private readonly informationService:InformationService = inject(InformationService);
+  private readonly releaseService:ReleaseService = inject(ReleaseService);
   private readonly themeService:ThemeService = inject(ThemeService);
   private readonly breakpointObserver:BreakpointObserver = inject(BreakpointObserver);
 
@@ -36,6 +38,7 @@ export class SettingsComponent {
 
   protected readonly loading:WritableSignal<boolean> = signal(true);
   protected readonly saving:WritableSignal<boolean> = signal(false);
+  protected readonly checkingRelease:WritableSignal<boolean> = signal(false);
   protected readonly timezoneLoadError:WritableSignal<string | null> = signal<string | null>(null);
   protected readonly timezoneOptions:WritableSignal<ReadonlyArray<string>> = signal<ReadonlyArray<string>>([]);
   protected readonly timezoneSearch:WritableSignal<string> = signal<string>('');
@@ -136,6 +139,19 @@ export class SettingsComponent {
       template: settings.template,
       color: settings.color,
     });
+  }
+
+  protected checkForNewVersions():void {
+    if ( this.checkingRelease() ) { return; }
+    this.checkingRelease.set(true);
+    this.releaseService
+      .refresh(true)
+      .pipe(finalize(():void => this.checkingRelease.set(false)))
+      .subscribe({
+        error: (error:HttpErrorResponse):void => {
+          this.alertService.error(error.error?.message || 'Unable to check for new versions.');
+        }
+      });
   }
 
   private loadTimezones():void {

--- a/frontend/src/app/services/release.service.ts
+++ b/frontend/src/app/services/release.service.ts
@@ -1,0 +1,38 @@
+import { computed, Injectable, signal, Signal, WritableSignal } from '@angular/core';
+import { Observable, tap } from 'rxjs';
+import { HttpService } from 'src/app/services/http.service';
+import { ReleaseType } from 'src/app/types';
+
+@Injectable({ providedIn: 'root' })
+export class ReleaseService {
+
+  private readonly releaseState:WritableSignal<ReleaseType | null> = signal<ReleaseType | null>(null);
+
+  private readonly dismissedState:WritableSignal<boolean> = signal(false);
+
+  public readonly release:Signal<ReleaseType | null> = this.releaseState.asReadonly();
+
+  public readonly shouldShowDialog:Signal<boolean> = computed(():boolean => {
+    const release:ReleaseType | null = this.releaseState();
+    return release !== null && release.current !== release.latest && ! this.dismissedState();
+  });
+
+  constructor(
+    private readonly httpService:HttpService
+  ) {}
+
+  public refresh(force:boolean = false):Observable<ReleaseType> {
+    const uri:string = ( force ? '/release?force=true' : '/release' );
+    return this.httpService.GET<ReleaseType>(uri).pipe(
+      tap((release:ReleaseType):void => {
+        if ( force ) { this.dismissedState.set(false); }
+        this.releaseState.set(release);
+      })
+    );
+  }
+
+  public dismiss():void {
+    this.dismissedState.set(true);
+  }
+
+}

--- a/frontend/src/app/services/session.service.ts
+++ b/frontend/src/app/services/session.service.ts
@@ -7,13 +7,15 @@ import { InformationService } from 'src/app/services/information.service';
 import { LogsService } from 'src/app/services/logs.service';
 import { AuthenticateType, InformationType, JwtType, TokenType } from 'src/app/types';
 
+export type AuthenticationChange = 'login' | 'logout' | 'restored';
+
 @Injectable({ providedIn: 'root' })
 export class SessionService {
 
   private expirationTimer:ReturnType<typeof setTimeout> | null = null;
   private bootstrapSessionRequest:Observable<boolean> | null = null;
   private informationService:InformationService | null = null;
-  private readonly authenticationChangedSubject:Subject<void> = new Subject<void>();
+  private readonly authenticationChangedSubject:Subject<AuthenticationChange> = new Subject<AuthenticationChange>();
   private readonly readyState:WritableSignal<boolean> = signal(false);
   private readonly validState:WritableSignal<boolean> = signal(false);
   private readonly tokenState:WritableSignal<string> = signal('');
@@ -26,7 +28,7 @@ export class SessionService {
   private readonly startupErrorState:WritableSignal<string | null> = signal<string | null>(null);
   private readonly urlBeforeWaitState:WritableSignal<string> = signal('');
 
-  public readonly authenticationChangedEvent:Observable<void> = this.authenticationChangedSubject.asObservable();
+  public readonly authenticationChangedEvent:Observable<AuthenticationChange> = this.authenticationChangedSubject.asObservable();
   public readonly isReady:Signal<boolean> = this.readyState.asReadonly();
   public readonly isValid:Signal<boolean> = this.validState.asReadonly();
   public readonly isGuestUser:Signal<boolean> = computed(():boolean => ( this.roleState() === 'guest' ));
@@ -150,7 +152,7 @@ export class SessionService {
     this.readyState.set(true);
   }
 
-  private checkIfTokenIsValid():void {
+  private checkIfTokenIsValid(isNewLogin:boolean = false):void {
     this.readyState.set(false);
     if ( ! this.hasToken() ) {
       this.ensureBootstrapSessionIfNeeded().subscribe();
@@ -160,7 +162,7 @@ export class SessionService {
       next: ():void => {
         this.validState.set(true);
         this.readyState.set(true);
-        this.authenticationChangedSubject.next();
+        this.authenticationChangedSubject.next(( isNewLogin ? 'login' : 'restored' ));
       },
       error: (error):void => {
         this.logsService.error('[SessionService] verifyToken failed', error);
@@ -210,8 +212,7 @@ export class SessionService {
   public setNewTokenAndCheckIfIsValid(response:JwtType):void {
     this.applyTokenState(response.jwt);
     localStorage.setItem('JWT', response.jwt);
-    this.checkIfTokenIsValid();
-    this.authenticationChangedSubject.next();
+    this.checkIfTokenIsValid(true);
   }
 
   public tryAuthenticate(account:string, password:string, duration:number = 86400):Observable<boolean> {
@@ -272,7 +273,7 @@ export class SessionService {
                 this.validState.set(true);
                 this.readyState.set(true);
                 this.clearStartupError();
-                this.authenticationChangedSubject.next();
+                this.authenticationChangedSubject.next('login');
               }),
               map(():boolean => true),
               catchError((error):Observable<boolean> => {
@@ -322,7 +323,7 @@ export class SessionService {
   public logout():void {
     const hadToken:boolean = this.hasToken();
     this.destroySessionAndRemoveTokenFromLocalStorage();
-    if ( hadToken ) { this.authenticationChangedSubject.next(); }
+    if ( hadToken ) { this.authenticationChangedSubject.next('logout'); }
   }
 
   public setUrlBeforeWait(url:string):void {

--- a/frontend/src/app/types/index.ts
+++ b/frontend/src/app/types/index.ts
@@ -10,6 +10,7 @@ export * from 'src/app/types/jwt.type';
 export * from 'src/app/types/metadata.type';
 export * from 'src/app/types/pinned.type';
 export * from 'src/app/types/profile.type';
+export * from 'src/app/types/release.type';
 export * from 'src/app/types/search.type';
 export * from 'src/app/types/settings.type';
 export * from 'src/app/types/tree.type';

--- a/frontend/src/app/types/release.type.ts
+++ b/frontend/src/app/types/release.type.ts
@@ -1,0 +1,11 @@
+import type { ReleaseContract } from '@shared/contracts';
+
+export type ReleaseType = {
+  current:string;
+  latest:string;
+};
+
+type ReleaseShapeGuard = [ ReleaseContract ] extends [ ReleaseType ]
+  ? [ ReleaseType ] extends [ ReleaseContract ] ? true : never : never;
+const releaseShapeGuard:ReleaseShapeGuard = true;
+void releaseShapeGuard;

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -44,7 +44,12 @@ html {
   --app-monospace-font-family: Consolas, 'Courier New', Courier, monospace;
   --app-surface-color: #ffffff;
   --app-shell-accent-tint: color-mix(in srgb, var(--theme-color) 5%, #ffffff);
-  --app-shell-background: linear-gradient(145deg, #ffffff 0%, var(--app-shell-accent-tint) 100%);
+  --app-shell-background: linear-gradient(
+    90deg,
+    #ffffff 0%,
+    #ffffff 500px,
+    var(--app-shell-accent-tint) 100%
+  );
   --app-heading-shadow: 0 3px 6px rgb(0 0 0 / 9%);
   --app-control-shadow: 0 3px 6px rgb(0 0 0 / 9%);
   --app-divider-color: #dddddd;

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -276,6 +276,11 @@ h2.app-dialog-title {
   margin-bottom: 0;
 }
 
+.app-dialog-message {
+  margin: 0;
+  white-space: pre-line;
+}
+
 .app-dialog-close-button {
   margin-right: -0.25rem;
   margin-left: auto;

--- a/shared/contracts/index.ts
+++ b/shared/contracts/index.ts
@@ -11,6 +11,7 @@ export * from './jwt.contract';
 export * from './metadata.contract';
 export * from './pinned.contract';
 export * from './profile.contract';
+export * from './release.contract';
 export * from './search.contract';
 export * from './settings.contract';
 export * from './snapshot.contract';

--- a/shared/contracts/release.contract.ts
+++ b/shared/contracts/release.contract.ts
@@ -1,0 +1,4 @@
+export type ReleaseContract = {
+  current:string;
+  latest:string;
+};


### PR DESCRIPTION
This pull request introduces a new backend release check feature, updates the Docker port configuration, and makes several improvements to documentation and code style. The most important changes are summarized below.

---

**Release check feature:**

* Added a scheduled backend release check that contacts the Pulse service at startup and every eight hours, reporting the current package version and runtime mode. This includes a new `/api/release` endpoint (requires `manage` authorization) that returns the installed and latest release versions, and supports a `force` parameter to bypass the cache. The release contract and its API are documented in `ARCHITECTURE.md`. [[1]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L1-R7) [[2]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2R19) [[3]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2R36-R76) [[4]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L107-R124) [[5]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L118-R133) [[6]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L127-R143) [[7]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L138-R153) [[8]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L147-R163) [[9]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L159-R175) [[10]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L170-R185) [[11]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L180-R196) [[12]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR127) [[13]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdR192-R208)

* Added new dependencies to support scheduling and release checks: `@nestjs/schedule`, `cron`, and `luxon` (with types). [[1]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R21) [[2]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR17) [[3]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR2461-R2473) [[4]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR2994-R2999) [[5]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR5309-R5325) [[6]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR8275-R8283)

---

**Docker port and documentation updates:**

* Changed the default Docker port from `3000` to `3210` for both the frontend and backend API. Updated all relevant documentation files (`README.md`, `CONTRIBUTING.md`, `ARCHITECTURE.md`) and Docker run instructions to reflect this change. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R85) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R106) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L82-R82) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L93-R99) [[5]](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL61-R61)

---

**API and code improvements:**

* Improved API method signatures in `AppController` for consistency and clarity, making all route handler methods explicitly `public`. [[1]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L71-R86) [[2]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L81-R113) [[3]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L107-R124) [[4]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L118-R133) [[5]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L127-R143) [[6]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L138-R153) [[7]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L147-R163) [[8]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L159-R175) [[9]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L170-R185) [[10]](diffhunk://#diff-4cdd13738349194637751a514d806306b4460016259a507ae2cd07a2ace515e2L180-R196)

---

**ESLint configuration cleanup:**

* Removed Prettier integration and related rules from the backend ESLint configuration to simplify linting and avoid conflicts. [[1]](diffhunk://#diff-91cf0077970e95faf88f9d6465a633fb0946398900f9b64fef8995779d198273L3) [[2]](diffhunk://#diff-91cf0077970e95faf88f9d6465a633fb0946398900f9b64fef8995779d198273L13) [[3]](diffhunk://#diff-91cf0077970e95faf88f9d6465a633fb0946398900f9b64fef8995779d198273L32-L40)

---

**Documentation enhancements:**

* Added detailed documentation for the new release check mechanism and API in `ARCHITECTURE.md`.