### PR TITLE
Add image paste support into editor

### DIFF
--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -26,6 +26,7 @@ import {
   DocumentMode,
   DocumentPageData,
   EditorInsertRequest,
+  EditorPastedImageRequest,
   FooterComponent,
   HeaderComponent,
   InitializationComponent,
@@ -120,6 +121,8 @@ export class App implements AfterViewInit {
   protected readonly versioning:WritableSignal<boolean> = signal(false);
 
   protected readonly pendingEditorInsertRequest:WritableSignal<EditorInsertRequest | null> = signal<EditorInsertRequest | null>(null);
+
+  protected readonly pendingEditorPastedImageRequest:WritableSignal<EditorPastedImageRequest | null> = signal<EditorPastedImageRequest | null>(null);
 
   protected readonly isSavingDocument:WritableSignal<boolean> = signal(false);
 
@@ -263,15 +266,19 @@ export class App implements AfterViewInit {
 
   private readonly pendingEditPath:WritableSignal<string | null> = signal<string | null>(null);
   private editorInsertRequestSequence = 0;
+  private editorPastedImageRequestSequence = 0;
 
   protected readonly documentPageData:Signal<DocumentPageData> = computed<DocumentPageData>(():DocumentPageData => ( {
     document: this.currentDocument(),
     mode: this.mode(),
     editorRaw: this.editorRaw(),
     editorInsertRequest: this.pendingEditorInsertRequest(),
+    editorPastedImageRequest: this.pendingEditorPastedImageRequest(),
+    isSaving: this.isSavingDocument(),
     onEditorRawChange: (raw:string):void => this.onEditorRawChange(raw),
     onEditorInsertRequestApplied: (requestId:number):void => this.onEditorInsertRequestApplied(requestId),
-    onEditorAttachmentsChange: (attachments:ReadonlyArray<AttachmentType>):void => this.syncCurrentDocumentAttachments(attachments),
+    onEditorPastedImageRequestApplied: (requestId:number):void => this.onEditorPastedImageRequestApplied(requestId),
+    onEditorInitialDocumentSaveRequested: (image:File):void => this.requestInitialDocumentSave(image),
   } ));
 
   constructor() {
@@ -351,6 +358,14 @@ export class App implements AfterViewInit {
     this.pendingEditorInsertRequest.set({
       id: this.editorInsertRequestSequence,
       markdown,
+    });
+  }
+
+  private queuePastedImageRequest(image:File):void {
+    this.editorPastedImageRequestSequence += 1;
+    this.pendingEditorPastedImageRequest.set({
+      id: this.editorPastedImageRequestSequence,
+      image,
     });
   }
 
@@ -521,6 +536,63 @@ export class App implements AfterViewInit {
     });
   }
 
+  private requestInitialDocumentSave(image:File):void {
+    const document:DocumentType | null = this.currentDocument();
+    if ( document?.exists === true ) {
+      this.queuePastedImageRequest(image);
+      return;
+    }
+    if ( ! document || this.isSavingDocument() ) { return; }
+    const data:ConfirmData = {
+      title: 'Save document before uploading image',
+      message: 'The document must be saved before an image can be uploaded. Do you want to save this draft and continue?',
+      confirmLabel: 'Save and upload',
+      cancelLabel: 'Cancel',
+      confirmColor: 'primary',
+    };
+    this.dialog
+      .open(ConfirmComponent, { width: '90vw', maxWidth: '520px', data })
+      .afterClosed()
+      .subscribe((confirmed:boolean | undefined):void => {
+        if ( confirmed !== true ) { return; }
+        this.saveInitialDocumentAndUploadImage(image);
+      });
+  }
+
+  private saveInitialDocumentAndUploadImage(image:File):void {
+    if ( this.currentDocument()?.exists === true || this.isSavingDocument() ) { return; }
+    const path:string = this.currentPath();
+    const raw:string = this.editorRaw();
+    this.isSavingDocument.set(true);
+    this.httpService.POST<void>(`/document?path=${ encodeURIComponent(path) }`, {
+      raw,
+      versioning: this.versioning()
+    }).subscribe({
+      next: ():void => {
+        if ( this.currentPath() !== path ) {
+          this.isSavingDocument.set(false);
+          return;
+        }
+        this.currentDocument.update((document:DocumentType | null):DocumentType | null => {
+          if ( ! document ) { return null; }
+          return {
+            ...document,
+            exists: true,
+            content: { ...document.content, raw },
+          };
+        });
+        this.editorInitialRaw.set(raw);
+        this.isSavingDocument.set(false);
+        this.queuePastedImageRequest(image);
+        this.alertService.success('Document saved successfully.');
+      },
+      error: (error:HttpErrorResponse):void => {
+        this.isSavingDocument.set(false);
+        this.alertService.error(error.message || 'Unable to save document before uploading image.');
+      }
+    });
+  }
+
   private moveDocument(destination:string):void {
     if ( ! this.canMoveDocument() ) { return; }
     const sourcePath:string = this.currentPath();
@@ -598,6 +670,7 @@ export class App implements AfterViewInit {
   private loadDocumentForCurrentUrl():void {
     this.mode.set('view');
     this.pendingEditorInsertRequest.set(null);
+    this.pendingEditorPastedImageRequest.set(null);
     this.syncSearchQuery();
     const path:string = this.normalizePath(this.router.url);
     this.currentPath.set(path);
@@ -769,6 +842,11 @@ export class App implements AfterViewInit {
   protected onEditorInsertRequestApplied(requestId:number):void {
     if ( this.pendingEditorInsertRequest()?.id !== requestId ) { return; }
     this.pendingEditorInsertRequest.set(null);
+  }
+
+  protected onEditorPastedImageRequestApplied(requestId:number):void {
+    if ( this.pendingEditorPastedImageRequest()?.id !== requestId ) { return; }
+    this.pendingEditorPastedImageRequest.set(null);
   }
 
   protected onNavigationToggle():void {

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -271,6 +271,7 @@ export class App implements AfterViewInit {
     editorInsertRequest: this.pendingEditorInsertRequest(),
     onEditorRawChange: (raw:string):void => this.onEditorRawChange(raw),
     onEditorInsertRequestApplied: (requestId:number):void => this.onEditorInsertRequestApplied(requestId),
+    onEditorAttachmentsChange: (attachments:ReadonlyArray<AttachmentType>):void => this.syncCurrentDocumentAttachments(attachments),
   } ));
 
   constructor() {

--- a/frontend/src/app/app.utilities.ts
+++ b/frontend/src/app/app.utilities.ts
@@ -1,0 +1,23 @@
+const imageAttachmentExtensionsByMimeType:ReadonlyMap<string, string> = new Map<string, string>([
+  [ 'image/apng', 'apng' ],
+  [ 'image/avif', 'avif' ],
+  [ 'image/bmp', 'bmp' ],
+  [ 'image/gif', 'gif' ],
+  [ 'image/vnd.microsoft.icon', 'ico' ],
+  [ 'image/x-icon', 'ico' ],
+  [ 'image/jpeg', 'jpg' ],
+  [ 'image/png', 'png' ],
+  [ 'image/svg+xml', 'svg' ],
+  [ 'image/webp', 'webp' ],
+]);
+
+export const IMAGE_ATTACHMENT_EXTENSIONS:ReadonlySet<string> = new Set<string>(imageAttachmentExtensionsByMimeType.values());
+
+export function getImageAttachmentExtensionFromMimeType(mimeType:string):string | null {
+  return imageAttachmentExtensionsByMimeType.get(mimeType.trim().toLowerCase()) ?? null;
+}
+
+export function isImageAttachmentFileName(fileName:string):boolean {
+  const extension:string = fileName.trim().split('.').at(-1)?.toLowerCase() ?? '';
+  return IMAGE_ATTACHMENT_EXTENSIONS.has(extension);
+}

--- a/frontend/src/app/components/attachments/attachments.component.ts
+++ b/frontend/src/app/components/attachments/attachments.component.ts
@@ -1,6 +1,6 @@
 import { map, Observable } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, inject, signal, WritableSignal } from '@angular/core';
+import { Component, inject, OnInit, signal, WritableSignal } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -30,7 +30,7 @@ export type AttachmentsDialogResult = {
   styleUrl: './attachments.component.scss',
   imports: [ MatDialogModule, MatButtonModule, MatIconModule, MatListModule, MatProgressBarModule ],
 })
-export class AttachmentsComponent {
+export class AttachmentsComponent implements OnInit {
 
   private readonly alertService:AlertService = inject(AlertService);
   private readonly httpService:HttpService = inject(HttpService);
@@ -45,6 +45,10 @@ export class AttachmentsComponent {
   protected readonly deletingAttachmentFile:WritableSignal<string | null> = signal<string | null>(null);
 
   private selectedFile:File | null = null;
+
+  public ngOnInit():void {
+    this.refreshAttachments();
+  }
 
   protected close():void {
     this.dialogRef.close({

--- a/frontend/src/app/components/attachments/attachments.component.ts
+++ b/frontend/src/app/components/attachments/attachments.component.ts
@@ -7,6 +7,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { buildBackendUrl } from 'src/app/app.backend';
+import { isImageAttachmentFileName } from 'src/app/app.utilities';
 import { ConfirmComponent, ConfirmData } from 'src/app/components/confirm/confirm.component';
 import { AlertService } from 'src/app/services/alert.service';
 import { HttpService } from 'src/app/services/http.service';
@@ -111,8 +112,7 @@ export class AttachmentsComponent {
   }
 
   protected isImageAttachment(fileName:string):boolean {
-    const extension:string = fileName.trim().split('.').at(-1)?.toLowerCase() ?? '';
-    return [ 'apng', 'avif', 'bmp', 'gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp' ].includes(extension);
+    return isImageAttachmentFileName(fileName);
   }
 
   protected getPreviewUrl(attachment:AttachmentType):string {

--- a/frontend/src/app/components/document/document.component.html
+++ b/frontend/src/app/components/document/document.component.html
@@ -23,10 +23,14 @@
       <app-document-editor
         [raw]="editorRaw()"
         [documentPath]="document()?.metadata?.path ?? ''"
+        [documentExists]="document()?.exists === true"
+        [isSaving]="isSaving()"
         [insertRequest]="editorInsertRequest()"
+        [pastedImageRequest]="editorPastedImageRequest()"
         (rawChanged)="onEditorRawChange($event)"
         (insertRequestApplied)="onEditorInsertRequestApplied($event)"
-        (attachmentsChanged)="onEditorAttachmentsChange($event)"
+        (pastedImageRequestApplied)="onEditorPastedImageRequestApplied($event)"
+        (initialDocumentSaveRequested)="onEditorInitialDocumentSaveRequested($event)"
       />
     }
   </section>

--- a/frontend/src/app/components/document/document.component.html
+++ b/frontend/src/app/components/document/document.component.html
@@ -22,9 +22,11 @@
     @if (mode() === 'edit') {
       <app-document-editor
         [raw]="editorRaw()"
+        [documentPath]="document()?.metadata?.path ?? ''"
         [insertRequest]="editorInsertRequest()"
         (rawChanged)="onEditorRawChange($event)"
         (insertRequestApplied)="onEditorInsertRequestApplied($event)"
+        (attachmentsChanged)="onEditorAttachmentsChange($event)"
       />
     }
   </section>

--- a/frontend/src/app/components/document/document.component.ts
+++ b/frontend/src/app/components/document/document.component.ts
@@ -3,8 +3,8 @@ import { ROUTER_OUTLET_DATA } from '@angular/router';
 import { SessionService } from 'src/app/services/session.service';
 import { DocumentViewerComponent } from 'src/app/components/document/viewer/viewer.component';
 import { DocumentExistsComponent } from 'src/app/components/document/exists/exists.component';
-import { DocumentEditorComponent, EditorInsertRequest } from 'src/app/components/document/editor/editor.component';
-import { AttachmentType, DocumentType } from 'src/app/types';
+import { DocumentEditorComponent, EditorInsertRequest, EditorPastedImageRequest } from 'src/app/components/document/editor/editor.component';
+import { DocumentType } from 'src/app/types';
 
 export type DocumentMode = 'view' | 'edit';
 
@@ -13,9 +13,12 @@ export type DocumentPageData = {
   readonly mode:DocumentMode;
   readonly editorRaw:string;
   readonly editorInsertRequest:EditorInsertRequest | null;
+  readonly editorPastedImageRequest:EditorPastedImageRequest | null;
+  readonly isSaving:boolean;
   readonly onEditorRawChange:(raw:string) => void;
   readonly onEditorInsertRequestApplied:(requestId:number) => void;
-  readonly onEditorAttachmentsChange:(attachments:ReadonlyArray<AttachmentType>) => void;
+  readonly onEditorPastedImageRequestApplied:(requestId:number) => void;
+  readonly onEditorInitialDocumentSaveRequested:(image:File) => void;
 };
 
 @Component({
@@ -32,6 +35,8 @@ export class DocumentComponent {
   protected readonly mode:Signal<DocumentMode> = computed(():DocumentMode => this.pageData().mode);
   protected readonly editorRaw:Signal<string> = computed(():string => this.pageData().editorRaw);
   protected readonly editorInsertRequest:Signal<EditorInsertRequest | null> = computed(():EditorInsertRequest | null => this.pageData().editorInsertRequest);
+  protected readonly editorPastedImageRequest:Signal<EditorPastedImageRequest | null> = computed(():EditorPastedImageRequest | null => this.pageData().editorPastedImageRequest);
+  protected readonly isSaving:Signal<boolean> = computed(():boolean => this.pageData().isSaving);
   protected readonly canWrite:Signal<boolean> = computed(():boolean => this.sessionService.isValid() && this.sessionService.hasAuthorization('write'));
 
   protected onEditorRawChange(raw:string):void {
@@ -42,8 +47,12 @@ export class DocumentComponent {
     this.pageData().onEditorInsertRequestApplied(requestId);
   }
 
-  protected onEditorAttachmentsChange(attachments:ReadonlyArray<AttachmentType>):void {
-    this.pageData().onEditorAttachmentsChange(attachments);
+  protected onEditorPastedImageRequestApplied(requestId:number):void {
+    this.pageData().onEditorPastedImageRequestApplied(requestId);
+  }
+
+  protected onEditorInitialDocumentSaveRequested(image:File):void {
+    this.pageData().onEditorInitialDocumentSaveRequested(image);
   }
 
 }

--- a/frontend/src/app/components/document/document.component.ts
+++ b/frontend/src/app/components/document/document.component.ts
@@ -4,7 +4,7 @@ import { SessionService } from 'src/app/services/session.service';
 import { DocumentViewerComponent } from 'src/app/components/document/viewer/viewer.component';
 import { DocumentExistsComponent } from 'src/app/components/document/exists/exists.component';
 import { DocumentEditorComponent, EditorInsertRequest } from 'src/app/components/document/editor/editor.component';
-import { DocumentType } from 'src/app/types';
+import { AttachmentType, DocumentType } from 'src/app/types';
 
 export type DocumentMode = 'view' | 'edit';
 
@@ -15,6 +15,7 @@ export type DocumentPageData = {
   readonly editorInsertRequest:EditorInsertRequest | null;
   readonly onEditorRawChange:(raw:string) => void;
   readonly onEditorInsertRequestApplied:(requestId:number) => void;
+  readonly onEditorAttachmentsChange:(attachments:ReadonlyArray<AttachmentType>) => void;
 };
 
 @Component({
@@ -39,6 +40,10 @@ export class DocumentComponent {
 
   protected onEditorInsertRequestApplied(requestId:number):void {
     this.pageData().onEditorInsertRequestApplied(requestId);
+  }
+
+  protected onEditorAttachmentsChange(attachments:ReadonlyArray<AttachmentType>):void {
+    this.pageData().onEditorAttachmentsChange(attachments);
   }
 
 }

--- a/frontend/src/app/components/document/editor/editor.component.ts
+++ b/frontend/src/app/components/document/editor/editor.component.ts
@@ -5,11 +5,15 @@ import type EasyMDEType from 'easymde';
 import { getImageAttachmentExtensionFromMimeType } from 'src/app/app.utilities';
 import { AlertService } from 'src/app/services/alert.service';
 import { HttpService } from 'src/app/services/http.service';
-import { AttachmentType, DocumentType } from 'src/app/types';
 
 export type EditorInsertRequest = {
   readonly id:number;
   readonly markdown:string;
+};
+
+export type EditorPastedImageRequest = {
+  readonly id:number;
+  readonly image:File;
 };
 
 @Component({
@@ -21,10 +25,14 @@ export type EditorInsertRequest = {
 export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
   public readonly raw = input.required<string>();
   public readonly documentPath = input.required<string>();
+  public readonly documentExists = input.required<boolean>();
+  public readonly isSaving = input.required<boolean>();
   public readonly insertRequest = input<EditorInsertRequest | null>(null);
+  public readonly pastedImageRequest = input<EditorPastedImageRequest | null>(null);
   public readonly rawChanged = output<string>();
   public readonly insertRequestApplied = output<number>();
-  public readonly attachmentsChanged = output<ReadonlyArray<AttachmentType>>();
+  public readonly pastedImageRequestApplied = output<number>();
+  public readonly initialDocumentSaveRequested = output<File>();
   private readonly alertService:AlertService = inject(AlertService);
   private readonly destroyRef:DestroyRef = inject(DestroyRef);
   private readonly httpService:HttpService = inject(HttpService);
@@ -35,6 +43,7 @@ export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
   private readonly frontMatterLineIndexes = new Set<number>();
   private readonly isEditorReady:WritableSignal<boolean> = signal<boolean>(false);
   private lastAppliedInsertRequestId:number | null = null;
+  private lastAppliedPastedImageRequestId:number | null = null;
 
   public constructor() {
     effect(() => {
@@ -44,11 +53,17 @@ export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
       this.editor.value(raw);
       this.syncingFromInput = false;
     });
-
     effect(() => {
       const request:EditorInsertRequest | null = this.insertRequest();
       if ( ! this.isEditorReady() || ! request ) { return; }
       this.applyInsertRequest(request);
+    });
+    effect(() => {
+      const request:EditorPastedImageRequest | null = this.pastedImageRequest();
+      if ( ! this.isEditorReady() || ! request || this.lastAppliedPastedImageRequestId === request.id ) { return; }
+      this.lastAppliedPastedImageRequestId = request.id;
+      this.insertAndUploadImage(request.image);
+      this.pastedImageRequestApplied.emit(request.id);
     });
   }
 
@@ -158,11 +173,27 @@ export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    const fileName:string = `image_${ Date.now() }.${ extension }`;
-    const markdown:string = `![${ fileName }](./${ fileName })`;
-    this.insertMarkdownAtCursor(markdown);
-    this.uploadPastedImage(image, fileName);
+    if ( ! this.documentExists() ) {
+      if ( this.isSaving() ) {
+        this.alertService.warning('Wait for the document to be saved before pasting another image.');
+        return;
+      }
+      this.initialDocumentSaveRequested.emit(image);
+      return;
+    }
+    this.insertAndUploadImage(image);
   };
+
+  private insertAndUploadImage(image:File):void {
+    const extension:string | null = getImageAttachmentExtensionFromMimeType(image.type);
+    if ( ! extension ) {
+      this.alertService.error(`Unsupported image type: ${ image.type || 'unknown' }.`);
+      return;
+    }
+    const fileName:string = `image_${ Date.now() }.${ extension }`;
+    this.insertMarkdownAtCursor(`![${ fileName }](./${ fileName })`);
+    this.uploadPastedImage(image, fileName);
+  }
 
   private insertMarkdownAtCursor(markdown:string):void {
     if ( ! this.editor ) { return; }
@@ -179,20 +210,11 @@ export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
     this.httpService.UPLOAD<void>(uri, formData).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: ():void => {
         this.alertService.success('Image uploaded successfully.');
-        this.refreshAttachments();
       },
       error: (error:HttpErrorResponse):void => {
         this.removeMarkdownForFailedUpload(fileName);
         this.alertService.error(error.message || 'Unable to upload image.');
       }
-    });
-  }
-
-  private refreshAttachments():void {
-    const uri:string = `/document?path=${ encodeURIComponent(this.documentPath()) }`;
-    this.httpService.GET<DocumentType>(uri).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (document:DocumentType):void => this.attachmentsChanged.emit([ ...document.attachments ]),
-      error: (error:HttpErrorResponse):void => this.alertService.error(error.message || 'Image uploaded, but unable to refresh attachments.'),
     });
   }
 

--- a/frontend/src/app/components/document/editor/editor.component.ts
+++ b/frontend/src/app/components/document/editor/editor.component.ts
@@ -52,6 +52,7 @@ export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
       this.syncingFromInput = true;
       this.editor.value(raw);
       this.syncingFromInput = false;
+      this.refreshFrontMatterLineClasses();
     });
     effect(() => {
       const request:EditorInsertRequest | null = this.insertRequest();

--- a/frontend/src/app/components/document/editor/editor.component.ts
+++ b/frontend/src/app/components/document/editor/editor.component.ts
@@ -1,5 +1,11 @@
-import { AfterViewInit, Component, effect, ElementRef, input, OnDestroy, output, signal, viewChild, WritableSignal } from '@angular/core';
+import { AfterViewInit, Component, DestroyRef, effect, ElementRef, inject, input, OnDestroy, output, signal, viewChild, WritableSignal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import type EasyMDEType from 'easymde';
+import { getImageAttachmentExtensionFromMimeType } from 'src/app/app.utilities';
+import { AlertService } from 'src/app/services/alert.service';
+import { HttpService } from 'src/app/services/http.service';
+import { AttachmentType, DocumentType } from 'src/app/types';
 
 export type EditorInsertRequest = {
   readonly id:number;
@@ -14,9 +20,14 @@ export type EditorInsertRequest = {
 })
 export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
   public readonly raw = input.required<string>();
+  public readonly documentPath = input.required<string>();
   public readonly insertRequest = input<EditorInsertRequest | null>(null);
   public readonly rawChanged = output<string>();
   public readonly insertRequestApplied = output<number>();
+  public readonly attachmentsChanged = output<ReadonlyArray<AttachmentType>>();
+  private readonly alertService:AlertService = inject(AlertService);
+  private readonly destroyRef:DestroyRef = inject(DestroyRef);
+  private readonly httpService:HttpService = inject(HttpService);
   private readonly editorTextarea = viewChild.required<ElementRef<HTMLTextAreaElement>>('editorTextarea');
   private editor:EasyMDEType | null = null;
   private editorInitializationToken = 0;
@@ -51,6 +62,7 @@ export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
     if ( ! this.editor ) { return; }
     this.clearFrontMatterLineClasses();
     this.editor.codemirror.off('change', this.onEditorContentChange);
+    this.editor.codemirror.getWrapperElement().removeEventListener('paste', this.onEditorPaste);
     this.editor.toTextArea();
     this.editor.cleanup();
     this.editor = null;
@@ -76,6 +88,7 @@ export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
     });
     this.refreshFrontMatterLineClasses();
     this.editor.codemirror.on('change', this.onEditorContentChange);
+    this.editor.codemirror.getWrapperElement().addEventListener('paste', this.onEditorPaste);
     this.isEditorReady.set(true);
   }
 
@@ -123,6 +136,73 @@ export class DocumentEditorComponent implements AfterViewInit, OnDestroy {
     this.lastAppliedInsertRequestId = request.id;
     this.insertRequestApplied.emit(request.id);
     this.editor.codemirror.focus();
+  }
+
+  private readonly onEditorPaste = (event:ClipboardEvent):void => {
+    const images:File[] = Array.from(event.clipboardData?.items ?? [])
+      .filter((item:DataTransferItem):boolean => item.kind === 'file' && item.type.startsWith('image/'))
+      .map((item:DataTransferItem):File | null => item.getAsFile())
+      .filter((file:File | null):file is File => file !== null);
+    if ( images.length === 0 ) { return; }
+
+    event.preventDefault();
+    if ( images.length > 1 ) {
+      this.alertService.error('Paste one image at a time.');
+      return;
+    }
+
+    const image:File = images[0];
+    const extension:string | null = getImageAttachmentExtensionFromMimeType(image.type);
+    if ( ! extension ) {
+      this.alertService.error(`Unsupported image type: ${ image.type || 'unknown' }.`);
+      return;
+    }
+
+    const fileName:string = `image_${ Date.now() }.${ extension }`;
+    const markdown:string = `![${ fileName }](./${ fileName })`;
+    this.insertMarkdownAtCursor(markdown);
+    this.uploadPastedImage(image, fileName);
+  };
+
+  private insertMarkdownAtCursor(markdown:string):void {
+    if ( ! this.editor ) { return; }
+    const document = this.editor.codemirror.getDoc();
+    const cursor = document.getCursor('from');
+    document.replaceRange(markdown, cursor, cursor);
+  }
+
+  private uploadPastedImage(image:File, fileName:string):void {
+    const uploadedImage:File = new File([ image ], fileName, { type: image.type });
+    const formData:FormData = new FormData();
+    formData.set('file', uploadedImage, fileName);
+    const uri:string = `/attachment?path=${ encodeURIComponent(this.documentPath()) }&file=${ encodeURIComponent(fileName) }`;
+    this.httpService.UPLOAD<void>(uri, formData).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: ():void => {
+        this.alertService.success('Image uploaded successfully.');
+        this.refreshAttachments();
+      },
+      error: (error:HttpErrorResponse):void => {
+        this.removeMarkdownForFailedUpload(fileName);
+        this.alertService.error(error.message || 'Unable to upload image.');
+      }
+    });
+  }
+
+  private refreshAttachments():void {
+    const uri:string = `/document?path=${ encodeURIComponent(this.documentPath()) }`;
+    this.httpService.GET<DocumentType>(uri).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (document:DocumentType):void => this.attachmentsChanged.emit([ ...document.attachments ]),
+      error: (error:HttpErrorResponse):void => this.alertService.error(error.message || 'Image uploaded, but unable to refresh attachments.'),
+    });
+  }
+
+  private removeMarkdownForFailedUpload(fileName:string):void {
+    if ( ! this.editor ) { return; }
+    const escapedFileName:string = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern:RegExp = new RegExp(String.raw`!\[(?:\\.|[^\]\\])*\]\(\./${ escapedFileName }\)`);
+    const currentRaw:string = this.editor.value();
+    const rawWithoutFailedImage:string = currentRaw.replace(pattern, '');
+    if ( rawWithoutFailedImage !== currentRaw ) { this.editor.value(rawWithoutFailedImage); }
   }
 
 }


### PR DESCRIPTION
This pull request introduces support for pasting images directly into the document editor, with logic to handle saving unsaved documents before uploading images. It also refactors how image file types are detected and improves the extensibility and maintainability of the image attachment logic. The main changes are grouped below:

### Image Paste and Upload Functionality

* Added new `EditorPastedImageRequest` type and associated signals and methods in `app.ts`, `document.component.ts`, and `editor.component.ts` to support queuing, handling, and tracking image paste/upload requests in the editor. This includes logic to prompt the user to save the document first if it hasn't been saved yet, and to handle the image upload after saving. [[1]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R29) [[2]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R125-R126) [[3]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R269-R281) [[4]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R364-R371) [[5]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R539-R595) [[6]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R673) [[7]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R847-R851) [[8]](diffhunk://#diff-272711f6c6893e9567c7dec905fa347f80f2a37610df0bca2a19b7b765c1ce63L6-R6) [[9]](diffhunk://#diff-272711f6c6893e9567c7dec905fa347f80f2a37610df0bca2a19b7b765c1ce63R16-R21) [[10]](diffhunk://#diff-272711f6c6893e9567c7dec905fa347f80f2a37610df0bca2a19b7b765c1ce63R38-R39) [[11]](diffhunk://#diff-272711f6c6893e9567c7dec905fa347f80f2a37610df0bca2a19b7b765c1ce63R50-R57) [[12]](diffhunk://#diff-471816835a551bf96bf73ff7142923457aaa82f5ef0380346aced2a3a92e8ca4R25-R33) [[13]](diffhunk://#diff-95742260e9e29e7b4383bab3289b1aa8bb8ae93adbd4595b071f64389259daaeL1-R18) [[14]](diffhunk://#diff-95742260e9e29e7b4383bab3289b1aa8bb8ae93adbd4595b071f64389259daaeR27-R46) [[15]](diffhunk://#diff-95742260e9e29e7b4383bab3289b1aa8bb8ae93adbd4595b071f64389259daaeR55-R68)

* Updated the editor to listen for paste events, extract pasted images, and trigger the upload-and-insert flow. The editor also emits events when an image paste request is applied, ensuring the UI and state remain in sync. [[1]](diffhunk://#diff-95742260e9e29e7b4383bab3289b1aa8bb8ae93adbd4595b071f64389259daaeR55-R68) [[2]](diffhunk://#diff-95742260e9e29e7b4383bab3289b1aa8bb8ae93adbd4595b071f64389259daaeR81) [[3]](diffhunk://#diff-95742260e9e29e7b4383bab3289b1aa8bb8ae93adbd4595b071f64389259daaeR107)

### Image Attachment Utilities Refactor

* Centralized image extension and MIME type detection logic in new utility functions (`getImageAttachmentExtensionFromMimeType`, `isImageAttachmentFileName`, and `IMAGE_ATTACHMENT_EXTENSIONS`) in `app.utilities.ts`.

* Updated `AttachmentsComponent` to use the new utility for image type detection, improving maintainability and consistency. [[1]](diffhunk://#diff-fb5aaa6028430b24a4eaffbcb1677f240a0a1050ef93db34e1faee44dc910a84L3-R10) [[2]](diffhunk://#diff-fb5aaa6028430b24a4eaffbcb1677f240a0a1050ef93db34e1faee44dc910a84L114-R119)

### Attachments Component Improvements

* Changed `AttachmentsComponent` to implement `OnInit` and call `refreshAttachments()` on initialization, ensuring the attachment list is up-to-date when the dialog opens. [[1]](diffhunk://#diff-fb5aaa6028430b24a4eaffbcb1677f240a0a1050ef93db34e1faee44dc910a84L32-R33) [[2]](diffhunk://#diff-fb5aaa6028430b24a4eaffbcb1677f240a0a1050ef93db34e1faee44dc910a84R49-R52)

---

These changes collectively provide a seamless experience for users pasting images into documents, ensure documents are saved before image uploads, and improve code maintainability regarding image file type handling.