### PR TITLE
Document clipboard image uploads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -386,6 +386,17 @@ is `true` and `content.md` already exists, the backend first copies the current 
 copy fails the store operation. New documents never create a version. `_versions` is an internal archive and is not
 exposed through document APIs.
 
+### Image pasting
+
+The document editor accepts one supported image from the clipboard at a time. For an existing document, it generates a
+timestamped attachment file name, inserts a relative Markdown image reference at the cursor, and uploads the image
+through the existing `POST /api/attachment` endpoint. The attachment is stored alongside `content.md`.
+
+For a new document, the editor asks the user to save the draft before uploading the image, then continues the same
+insert-and-upload flow. Unsupported image types, multiple pasted images, and uploads attempted while the initial save
+is in progress produce an actionable error. If the attachment upload fails, the editor removes the Markdown reference
+it inserted for that image.
+
 ```
 ┌─────────────────────────────────────────┐
 │ MetadataContract                        │

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _Please consider supporting this project by making a donation via [PayPal](https
 - Support for Mermaid diagrams
 - Unlimited page revisions
 - Uploading and downloading Attachments
-- Uploading images ~~(also from clipboard)~~
+- Uploading images (also from clipboard)
 - Content can be categorized in namespaces
 - Public and private browsing
 - Desktop and remote Sync


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file, clarifying that uploading images from the clipboard is supported.

- Documentation update:
  * [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31): The note about uploading images has been updated to indicate that uploading from the clipboard is supported, removing the strikethrough formatting.