### PR TITLE
Set trust proxy for Express instance

### DIFF
--- a/pulse/src/main.ts
+++ b/pulse/src/main.ts
@@ -14,6 +14,7 @@ async function bootstrap():Promise<void> {
   const express:NestExpressApplication = app as NestExpressApplication;
   app.setGlobalPrefix('/api');
   const expressInstance = express.getHttpAdapter().getInstance();
+  expressInstance.set('trust proxy', 1);
   expressInstance.get('/', (_request, response):void => {
     response.type('html').send(DASHBOARD_HTML);
   });


### PR DESCRIPTION
This pull request makes a small configuration change to the Express server. The change ensures that the app correctly handles proxy headers, which is important when deploying behind a reverse proxy (such as in production environments).

* Express server configuration:
  * [`pulse/src/main.ts`](diffhunk://#diff-9c17e610ae211c82adae874f894cb00fbe9b49934bc03f7933c6db6d51b7251bR17): Set the `trust proxy` setting to `1` on the Express instance to trust the first proxy in the chain.