### PR TITLE
Implement settings cache in browser

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -515,8 +515,19 @@ The Angular application uses standalone components and hash-based routing. In de
 | `/#/trash`        | `delete`                                     |
 | `/#/**`           | `read`                                       |
 
-The application initializer loads runtime information and Markdown plugins. While the dataset is uninitialized, route
-guards allow initialization UI access regardless of normal route policy.
+The application initializer restores cached settings, loads runtime information, and loads Markdown plugins. While the
+dataset is uninitialized, route guards allow initialization UI access regardless of normal route policy.
+
+### Settings lifecycle
+
+The frontend stores the complete settings object in `localStorage` under `SETTINGS`. `SettingsService` restores this
+value into its Angular signal during application initialization, making settings available before the backend responds.
+Successful `GET /api/settings` and `PUT /api/settings` requests replace the signal and cached object in full. Request
+failures preserve the last available value. A successful information response with `initialized: false` clears both the
+signal and cache because the stored settings no longer describe the active dataset.
+
+The root application observes the settings signal and delegates `template` and `color` application to `ThemeService`.
+`ThemeService` owns only the visual state and does not persist a separate theme cache.
 
 ### Session lifecycle
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ _Please consider supporting this project by making a donation via [PayPal](https
 - Desktop and remote Sync
 - Syntax highlighting
 - ~~Multi-language~~
-- ~~Dark mode~~
+- Dark mode
 - and many more...
 
 ~~Striked~~ features are work in progress.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -24,6 +24,7 @@ Keep new/refactored code in the same layer where responsibility already exists.
 3. Keep backward compatibility for routes, component inputs/outputs, and expected UI flows.
 4. Reuse existing components/config/routes before introducing new abstractions.
 5. Avoid silent fallbacks: surface explicit, meaningful errors in UI and service flows.
+6. Check if you need to update also the .md files with new documentation. 
 
 ## TypeScript Best Practices
 

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -6,7 +6,7 @@ import { provideRouter, withHashLocation } from '@angular/router';
 import { MARKED_OPTIONS, provideMarkdown, SANITIZE } from 'ngx-markdown';
 import { InformationService } from 'src/app/services/information.service';
 import { ParserService } from 'src/app/services/parser.service';
-import { ThemeService } from 'src/app/services/theme.service';
+import { SettingsService } from 'src/app/services/settings.service';
 import { routes } from 'src/app/app.routes';
 
 export const appConfig:ApplicationConfig = {
@@ -17,7 +17,7 @@ export const appConfig:ApplicationConfig = {
     },
     importProvidersFrom(MatSnackBarModule),
     provideAppInitializer(():Promise<void> => {
-      inject(ThemeService).restore();
+      inject(SettingsService).restore();
       const informationService:InformationService = inject(InformationService);
       void informationService.load();
       const parserService:ParserService = inject(ParserService);

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -282,6 +282,11 @@ export class App implements AfterViewInit {
   } ));
 
   constructor() {
+    effect(():void => {
+      const settings:SettingsType | null = this.settingsService.settings();
+      if ( settings === null ) { return; }
+      this.themeService.apply(settings.template, settings.color);
+    });
     effect(():void => this.openPrivacyModalIfNeeded());
     effect(():void => this.openReleaseDialogIfNeeded());
     this.loadInformationBoundState();
@@ -370,8 +375,9 @@ export class App implements AfterViewInit {
   }
 
   private loadInformationBoundState():void {
-    if ( ! this.informationService.isInitialized() ) {
-      this.settingsService.clear();
+    const information:InformationType | null = this.informationService.retrieve();
+    if ( ! information?.initialized ) {
+      if ( information !== null ) { this.settingsService.clear(); }
       this.pinnedDocuments.set([]);
       this.isAuthenticated.set(false);
       this.isGuestUser.set(false);
@@ -658,9 +664,6 @@ export class App implements AfterViewInit {
 
   private loadSettings():void {
     this.settingsService.load().subscribe({
-      next: (settings:SettingsType):void => {
-        this.themeService.apply(settings.template, settings.color);
-      },
       error: (error:HttpErrorResponse):void => {
         console.error(error.message || 'Unable to load settings');
       }

--- a/frontend/src/app/components/settings/settings.component.ts
+++ b/frontend/src/app/components/settings/settings.component.ts
@@ -9,10 +9,9 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
-import { HttpService } from 'src/app/services/http.service';
 import { AlertService } from 'src/app/services/alert.service';
 import { InformationService } from 'src/app/services/information.service';
-import { ThemeService } from 'src/app/services/theme.service';
+import { SettingsService } from 'src/app/services/settings.service';
 import { SettingsType } from 'src/app/types';
 import { ReleaseService } from 'src/app/services/release.service';
 
@@ -28,10 +27,9 @@ export class SettingsComponent {
   private initialSettings:SettingsType | null = null;
 
   private readonly alertService:AlertService = inject(AlertService);
-  private readonly httpService:HttpService = inject(HttpService);
   private readonly informationService:InformationService = inject(InformationService);
   private readonly releaseService:ReleaseService = inject(ReleaseService);
-  private readonly themeService:ThemeService = inject(ThemeService);
+  private readonly settingsService:SettingsService = inject(SettingsService);
   private readonly breakpointObserver:BreakpointObserver = inject(BreakpointObserver);
 
   private readonly formBuilder:FormBuilder = inject(FormBuilder);
@@ -95,14 +93,13 @@ export class SettingsComponent {
     };
 
     this.saving.set(true);
-    this.httpService
-      .PUT<void>('/settings', request)
+    this.settingsService
+      .update(request)
       .pipe(finalize(():void => this.saving.set(false)))
       .subscribe({
         next: ():void => {
           this.initialSettings = request;
           this.patchForm(request);
-          this.themeService.apply(request.template, request.color);
           this.alertService.success('Settings updated successfully.');
         },
         error: (error:HttpErrorResponse):void => {
@@ -113,8 +110,8 @@ export class SettingsComponent {
 
   private loadSettings():void {
     this.loading.set(true);
-    this.httpService
-      .GET<SettingsType>('/settings')
+    this.settingsService
+      .load()
       .pipe(finalize(() => this.loading.set(false)))
       .subscribe({
         next: (settings:SettingsType):void => {

--- a/frontend/src/app/services/settings.service.ts
+++ b/frontend/src/app/services/settings.service.ts
@@ -6,22 +6,60 @@ import { SettingsType } from 'src/app/types';
 @Injectable({ providedIn: 'root' })
 export class SettingsService {
 
+  private readonly cacheKey:string = 'SETTINGS';
   private readonly currentSettings:WritableSignal<SettingsType | null> = signal<SettingsType | null>(null);
 
   public readonly settings:Signal<SettingsType | null> = this.currentSettings.asReadonly();
 
+  constructor(private readonly httpService:HttpService) {}
+
   public load():Observable<SettingsType> {
-    return this.httpService.GET<SettingsType>('/settings').pipe(tap((settings:SettingsType):void => this.currentSettings.set(settings)));
+    return this.httpService.GET<SettingsType>('/settings').pipe(tap((settings:SettingsType):void => this.set(settings)));
+  }
+
+  public update(settings:SettingsType):Observable<void> {
+    return this.httpService.PUT<void>('/settings', settings).pipe(tap(():void => this.set(settings)));
+  }
+
+  public restore():void {
+    let cachedValue:string | null;
+    try {
+      cachedValue = localStorage.getItem(this.cacheKey);
+    } catch (error:unknown) {
+      console.warn('[SettingsService] unable to read settings cache', error);
+      return;
+    }
+    if ( cachedValue === null ) { return; }
+
+    try {
+      // The settings cache is intentionally trusted because the application writes the complete backend contract.
+      this.currentSettings.set(JSON.parse(cachedValue) as SettingsType);
+    } catch (error:unknown) {
+      console.warn('[SettingsService] invalid settings cache', error);
+      this.clear();
+    }
   }
 
   public clear():void {
     this.currentSettings.set(null);
+    try {
+      localStorage.removeItem(this.cacheKey);
+    } catch (error:unknown) {
+      console.warn('[SettingsService] unable to clear settings cache', error);
+    }
   }
 
   public timezone():string {
     return this.settings()?.timezone ?? 'UTC';
   }
 
-  constructor(private readonly httpService:HttpService) {}
+  private set(settings:SettingsType):void {
+    this.currentSettings.set(settings);
+    try {
+      localStorage.setItem(this.cacheKey, JSON.stringify(settings));
+    } catch (error:unknown) {
+      console.warn('[SettingsService] unable to store settings cache', error);
+    }
+  }
 
 }

--- a/frontend/src/app/services/theme.service.ts
+++ b/frontend/src/app/services/theme.service.ts
@@ -2,71 +2,15 @@ import { DOCUMENT } from '@angular/common';
 import { Injectable, inject, Signal, signal, WritableSignal } from '@angular/core';
 import { SettingsType } from 'src/app/types';
 
-type CachedTheme = Pick<SettingsType, 'template' | 'color'>;
-
 @Injectable({ providedIn: 'root' })
 export class ThemeService {
 
-  private readonly cacheKey:string = 'THEME';
   private readonly document:Document = inject(DOCUMENT);
   private readonly activeTemplate:WritableSignal<SettingsType['template']> = signal<SettingsType['template']>('light');
 
   public readonly template:Signal<SettingsType['template']> = this.activeTemplate.asReadonly();
 
   public apply(template:SettingsType['template'], color:string):void {
-    this.update(template, color);
-    try {
-      localStorage.setItem(this.cacheKey, JSON.stringify({ template, color } satisfies CachedTheme));
-    } catch (error:unknown) {
-      console.warn('[ThemeService] unable to store theme cache', error);
-    }
-  }
-
-  public restore():void {
-    let cachedValue:string | null;
-    try {
-      cachedValue = localStorage.getItem(this.cacheKey);
-    } catch (error:unknown) {
-      console.warn('[ThemeService] unable to read theme cache', error);
-      return;
-    }
-    if ( cachedValue === null ) { return; }
-
-    let cachedTheme:unknown;
-    try {
-      cachedTheme = JSON.parse(cachedValue);
-    } catch (error:unknown) {
-      console.warn('[ThemeService] invalid theme cache', error);
-      this.clearCache();
-      return;
-    }
-    if ( ! this.isCachedTheme(cachedTheme) ) {
-      console.warn('[ThemeService] invalid theme cache');
-      this.clearCache();
-      return;
-    }
-    this.update(cachedTheme.template, cachedTheme.color);
-  }
-
-  private clearCache():void {
-    try {
-      localStorage.removeItem(this.cacheKey);
-    } catch (error:unknown) {
-      console.warn('[ThemeService] unable to clear theme cache', error);
-    }
-  }
-
-  private isCachedTheme(value:unknown):value is CachedTheme {
-    return typeof value === 'object'
-      && value !== null
-      && 'template' in value
-      && ( value.template === 'light' || value.template === 'dark' )
-      && 'color' in value
-      && typeof value.color === 'string'
-      && /^#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(value.color);
-  }
-
-  private update(template:SettingsType['template'], color:string):void {
     const documentElement:HTMLElement = this.document.documentElement;
     documentElement.classList.toggle('app-theme-dark', template === 'dark');
     documentElement.style.setProperty('--theme-color', color);


### PR DESCRIPTION
This pull request refactors how application settings and theme preferences are handled and persisted in the frontend. The main change is consolidating settings and theme state into the `SettingsService`, removing theme-specific caching from `ThemeService`, and ensuring settings are restored from `localStorage` during app initialization. This results in a single source of truth for settings, more robust cache management, and improved synchronization between the UI and backend state.

**Settings and Theme Management Refactor:**

* `SettingsService` now handles caching, restoring, updating, and clearing the complete settings object in `localStorage`, including theme preferences. The service exposes methods to load, update, and restore settings, and synchronizes these with the backend and the UI. (`frontend/src/app/services/settings.service.ts` [frontend/src/app/services/settings.service.tsR9-R63](diffhunk://#diff-d3c748abe37ebc603233fbd7fc27ac6b0516d90484b629abd9309547223445d2R9-R63))
* The application initializer and `App` component have been updated to restore settings from cache on startup, apply theme preferences reactively, and clear the cache if the dataset is uninitialized. (`frontend/src/app/app.config.ts` [[1]](diffhunk://#diff-6ce4075f3c779236c0e31e9353fbd8a07f68dfc609a62adc6c38b7bfa90837f1L9-R9) [[2]](diffhunk://#diff-6ce4075f3c779236c0e31e9353fbd8a07f68dfc609a62adc6c38b7bfa90837f1L20-R20); `frontend/src/app/app.ts` [[3]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465R285-R289) [[4]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465L373-R380) [[5]](diffhunk://#diff-0091d0264f0bfcffa7fe38c04c7cbcb6edc5b965d372bfc5754d5dbb353c3465L661-L663)
* All theme caching and restoration logic has been removed from `ThemeService`, which now only applies the visual theme based on current settings, delegating persistence to `SettingsService`. (`frontend/src/app/services/theme.service.ts` [frontend/src/app/services/theme.service.tsL5-L69](diffhunk://#diff-3adbaefbb028fc0227a9f950ed274f84ee222b1bc8faaed16ccd1cb078109336L5-L69))

**Settings UI and API Integration:**

* The `SettingsComponent` now uses `SettingsService` for loading and updating settings, and no longer directly interacts with the HTTP service or manages theme application. (`frontend/src/app/components/settings/settings.component.ts` [[1]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000L12-R14) [[2]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000L31-R32) [[3]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000L98-L105) [[4]](diffhunk://#diff-c5022e3b01f408409bb4ee12ca092469cd02ff7ea7b175f225e8bf3cc00ce000L116-R114)

**Documentation Updates:**

* The settings lifecycle and caching behavior are documented in `ARCHITECTURE.md`, clarifying how settings are loaded, cached, and invalidated. (`ARCHITECTURE.md` [ARCHITECTURE.mdL518-R530](diffhunk://#diff-8f6366fd8e7a5fa30f7f05879999195b7cf5fa1e3d157822eb37f0e91d226cfdL518-R530))
* A reminder to update documentation is added to the agents guidelines. (`frontend/AGENTS.md` [frontend/AGENTS.mdR27](diffhunk://#diff-bd492002340e08c1a80064210146f37abfd91630027add166548233cc645f6a8R27))
* The README is updated to reflect dark mode as a completed feature. (`README.md` [README.mdL37-R37](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37))